### PR TITLE
Enhance discovery with I/O JSON schemas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default = ["http_server", "rand", "uuid", "tracing-span-filter"]
 hyper = ["dep:hyper", "http-body-util", "restate-sdk-shared-core/http"]
 http_server = ["hyper", "hyper/server", "hyper/http2", "hyper-util", "tokio/net", "tokio/signal", "tokio/macros"]
 tracing-span-filter = ["dep:tracing-subscriber"]
+schemars = ["dep:schemars"]
 
 [dependencies]
 bytes = "1.10"
@@ -30,6 +31,7 @@ rand = { version = "0.9", optional = true }
 regress = "0.10"
 restate-sdk-macros = { version = "0.3", path = "macros" }
 restate-sdk-shared-core = { git = "https://github.com/restatedev/sdk-shared-core.git", branch = "main", features = ["request_identity", "sha2_random_seed", "http"] }
+schemars = { version = "1.0.0-alpha.17", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "2.0"
@@ -44,6 +46,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 trybuild = "1.0"
 reqwest = { version = "0.12", features = ["json"] }
 rand = "0.9"
+schemars = "1.0.0-alpha.17"
 
 [build-dependencies]
 jsonptr = "0.5.1"

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -1,0 +1,64 @@
+use restate_sdk::prelude::*;
+/// Run with auto-generated schemas for `Json<Product>` using `schemars`:
+///   cargo run --example schema --features schemars
+///
+/// Run with primitive schemas only:
+///   cargo run --example schema
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+struct Product {
+    id: String,
+    name: String,
+    price_cents: u32,
+}
+
+#[restate_sdk::service]
+trait CatalogService {
+    async fn get_product_by_id(product_id: String) -> Result<Json<Product>, HandlerError>;
+    async fn save_product(product: Json<Product>) -> Result<String, HandlerError>;
+    async fn is_in_stock(product_id: String) -> Result<bool, HandlerError>;
+}
+
+struct CatalogServiceImpl;
+
+impl CatalogService for CatalogServiceImpl {
+    async fn get_product_by_id(
+        &self,
+        ctx: Context<'_>,
+        product_id: String,
+    ) -> Result<Json<Product>, HandlerError> {
+        ctx.sleep(Duration::from_millis(50)).await?;
+        Ok(Json(Product {
+            id: product_id,
+            name: "Sample Product".to_string(),
+            price_cents: 1995,
+        }))
+    }
+
+    async fn save_product(
+        &self,
+        _ctx: Context<'_>,
+        product: Json<Product>,
+    ) -> Result<String, HandlerError> {
+        Ok(product.0.id)
+    }
+
+    async fn is_in_stock(
+        &self,
+        _ctx: Context<'_>,
+        product_id: String,
+    ) -> Result<bool, HandlerError> {
+        Ok(!product_id.contains("out-of-stock"))
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    HttpServer::new(Endpoint::builder().bind(CatalogServiceImpl.serve()).build())
+        .listen_and_serve("0.0.0.0:9080".parse().unwrap())
+        .await;
+}

--- a/macros/src/gen.rs
+++ b/macros/src/gen.rs
@@ -206,20 +206,29 @@ impl<'a> ServiceGenerator<'a> {
                 }
                 None => quote! {
                     Some(::restate_sdk::discovery::InputPayload {
-                        content_type: Some(<() as ::restate_sdk::serde::WithContentType>::content_type().to_string()),
-                        json_schema: Some(<() as ::restate_sdk::serde::WithSchema>::generate_schema()),
-                        required: Some(false),
+                        content_type: None,
+                        json_schema: None,
+                        required: None,
                     })
                 }
             };
 
             let output_ok = &handler.output_ok;
-            let output_schema = quote! {
-                Some(::restate_sdk::discovery::OutputPayload {
-                    content_type: Some(<#output_ok as ::restate_sdk::serde::WithContentType>::content_type().to_string()),
-                    json_schema: Some(<#output_ok as ::restate_sdk::serde::WithSchema>::generate_schema()),
-                    set_content_type_if_empty: Some(false),
-                })
+            let output_schema = match output_ok {
+                syn::Type::Tuple(tuple) if tuple.elems.is_empty() => quote! {
+                    Some(::restate_sdk::discovery::OutputPayload {
+                        content_type: None,
+                        json_schema: None,
+                        set_content_type_if_empty: Some(false),
+                    })
+                },
+                _ => quote! {
+                    Some(::restate_sdk::discovery::OutputPayload {
+                        content_type: Some(<#output_ok as ::restate_sdk::serde::WithContentType>::content_type().to_string()),
+                        json_schema: Some(<#output_ok as ::restate_sdk::serde::WithSchema>::generate_schema()),
+                        set_content_type_if_empty: Some(false),
+                    })
+                }
             };
 
             quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,8 @@
 //! - [Scheduling & Timers][crate::context::ContextTimers]: Let a handler pause for a certain amount of time. Restate durably tracks the timer across failures.
 //! - [Awakeables][crate::context::ContextAwakeables]: Durable Futures to wait for events and the completion of external tasks.
 //! - [Error Handling][crate::errors]: Restate retries failures infinitely. Use `TerminalError` to stop retries.
-//! - [Serialization][crate::serde]: The SDK serializes results to send them to the Server.
+//! - [Serialization][crate::serde]: The SDK serializes results to send them to the Server. Includes [Schema Generation][crate::serde::WithSchema] for API documentation & discovery.
 //! - [Serving][crate::http_server]: Start an HTTP server to expose services.
-//! - [JSON Schema Generation][crate::serde::WithSchema]: Automatically generate JSON Schemas for better discovery.
 //!
 //! # SDK Overview
 //!
@@ -505,82 +504,6 @@ pub use restate_sdk_macros::object;
 /// For more details, check the [`service` macro](macro@crate::service) documentation.
 pub use restate_sdk_macros::workflow;
 
-/// ### JSON Schema Generation
-///
-/// The SDK provides three approaches for generating JSON Schemas for handler inputs and outputs:
-///
-/// #### 1. Primitive Types
-///
-/// Primitive types (like `String`, `u32`, `bool`) have built-in schema implementations
-/// that work automatically without additional code:
-///
-/// ```rust
-/// use restate_sdk::prelude::*;
-///
-/// #[restate_sdk::service]
-/// trait SimpleService {
-///     async fn greet(name: String) -> HandlerResult<u32>;
-/// }
-/// ```
-///
-/// #### 2. Using Json<T> with schemars
-///
-/// For complex types wrapped in `Json<T>`, you need to add the `schemars` feature and derive `JsonSchema`:
-///
-/// ```rust
-/// use restate_sdk::prelude::*;
-///
-/// #[derive(serde::Serialize, serde::Deserialize)]
-/// #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-/// struct User {
-///     name: String,
-///     age: u32,
-/// }
-///
-/// #[restate_sdk::service]
-/// trait UserService {
-///     async fn register(user: Json<User>) -> HandlerResult<Json<User>>;
-/// }
-/// ```
-///
-/// To enable rich schema generation with `Json<T>`, add the `schemars` feature to your dependency:
-///
-/// ```toml
-/// [dependencies]
-/// restate-sdk = { version = "0.3", features = ["schemars"] }
-/// schemars = "1.0.0-alpha.17"
-/// ```
-///
-/// #### 3. Custom Implementation
-///
-/// You can also implement the `WithSchema` trait directly for your types to provide
-/// custom schemas without relying on the `schemars` feature:
-///
-/// ```rust
-/// use restate_sdk::serde::{WithSchema, WithContentType, Serialize, Deserialize};
-///
-/// #[derive(serde::Serialize, serde::Deserialize)]
-/// struct User {
-///     name: String,
-///     age: u32,
-/// }
-///
-/// // Implement WithSchema directly
-/// impl WithSchema for User {
-///     fn generate_schema() -> serde_json::Value {
-///         serde_json::json!({
-///             "type": "object",
-///             "properties": {
-///                 "name": {"type": "string"},
-///                 "age": {"type": "integer", "minimum": 0}
-///             },
-///             "required": ["name", "age"]
-///         })
-///     }
-/// }
-/// ```
-///
-///
 /// Prelude contains all the useful imports you need to get started with Restate.
 pub mod prelude {
     #[cfg(feature = "http_server")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 //! - [Error Handling][crate::errors]: Restate retries failures infinitely. Use `TerminalError` to stop retries.
 //! - [Serialization][crate::serde]: The SDK serializes results to send them to the Server.
 //! - [Serving][crate::http_server]: Start an HTTP server to expose services.
+//! - [JSON Schema Generation][crate::serde::WithSchema]: Automatically generate JSON Schemas for better discovery.
 //!
 //! # SDK Overview
 //!
@@ -504,6 +505,82 @@ pub use restate_sdk_macros::object;
 /// For more details, check the [`service` macro](macro@crate::service) documentation.
 pub use restate_sdk_macros::workflow;
 
+/// ### JSON Schema Generation
+///
+/// The SDK provides three approaches for generating JSON Schemas for handler inputs and outputs:
+///
+/// #### 1. Primitive Types
+///
+/// Primitive types (like `String`, `u32`, `bool`) have built-in schema implementations
+/// that work automatically without additional code:
+///
+/// ```rust
+/// use restate_sdk::prelude::*;
+///
+/// #[restate_sdk::service]
+/// trait SimpleService {
+///     async fn greet(name: String) -> HandlerResult<u32>;
+/// }
+/// ```
+///
+/// #### 2. Using Json<T> with schemars
+///
+/// For complex types wrapped in `Json<T>`, you need to add the `schemars` feature and derive `JsonSchema`:
+///
+/// ```rust
+/// use restate_sdk::prelude::*;
+///
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+/// struct User {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// #[restate_sdk::service]
+/// trait UserService {
+///     async fn register(user: Json<User>) -> HandlerResult<Json<User>>;
+/// }
+/// ```
+///
+/// To enable rich schema generation with `Json<T>`, add the `schemars` feature to your dependency:
+///
+/// ```toml
+/// [dependencies]
+/// restate-sdk = { version = "0.3", features = ["schemars"] }
+/// schemars = "1.0.0-alpha.17"
+/// ```
+///
+/// #### 3. Custom Implementation
+///
+/// You can also implement the `WithSchema` trait directly for your types to provide
+/// custom schemas without relying on the `schemars` feature:
+///
+/// ```rust
+/// use restate_sdk::serde::{WithSchema, WithContentType, Serialize, Deserialize};
+///
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct User {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// // Implement WithSchema directly
+/// impl WithSchema for User {
+///     fn generate_schema() -> serde_json::Value {
+///         serde_json::json!({
+///             "type": "object",
+///             "properties": {
+///                 "name": {"type": "string"},
+///                 "age": {"type": "integer", "minimum": 0}
+///             },
+///             "required": ["name", "age"]
+///         })
+///     }
+/// }
+/// ```
+///
+///
 /// Prelude contains all the useful imports you need to get started with Restate.
 pub mod prelude {
     #[cfg(feature = "http_server")]

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -35,6 +35,7 @@ trait SchemaTestService {
     async fn no_input_handler() -> HandlerResult<String>;
     async fn json_handler(input: Json<TestUser>) -> HandlerResult<Json<TestUser>>;
     async fn complex_handler(input: Json<Person>) -> HandlerResult<Json<HashMap<String, Person>>>;
+    async fn empty_output_handler(input: String) -> HandlerResult<()>;
 }
 
 struct SchemaTestServiceImpl;
@@ -60,13 +61,16 @@ impl SchemaTestService for SchemaTestServiceImpl {
     ) -> HandlerResult<Json<HashMap<String, Person>>> {
         Ok(Json(HashMap::from([("original".to_string(), input.0)])))
     }
+    async fn empty_output_handler(&self, _ctx: Context<'_>, _input: String) -> HandlerResult<()> {
+        Ok(())
+    }
 }
 
 #[test]
 fn schema_discovery_and_validation() {
     let discovery = ServeSchemaTestService::<SchemaTestServiceImpl>::discover();
     assert_eq!(discovery.name.to_string(), "SchemaTestService");
-    assert_eq!(discovery.handlers.len(), 4);
+    assert_eq!(discovery.handlers.len(), 5);
 
     for handler in &discovery.handlers {
         let input = handler
@@ -77,64 +81,88 @@ fn schema_discovery_and_validation() {
             .output
             .as_ref()
             .expect("Handler should have output schema");
-        let input_schema = input
-            .json_schema
-            .as_ref()
-            .expect("Input schema should exist");
-        let output_schema = output
-            .json_schema
-            .as_ref()
-            .expect("Output schema should exist");
 
         match handler.name.to_string().as_str() {
-            "string_handler" => {
-                assert_eq!(
-                    input_schema.get("type").and_then(|v| v.as_str()),
-                    Some("string")
-                );
-                assert_eq!(
-                    output_schema.get("type").and_then(|v| v.as_str()),
-                    Some("integer")
-                );
+            "string_handler" | "json_handler" | "complex_handler" | "empty_output_handler" => {
+                let input_schema = input
+                    .json_schema
+                    .as_ref()
+                    .expect("Input schema should exist for handlers with input");
+                let output_schema = output.json_schema.as_ref();
+
+                match handler.name.to_string().as_str() {
+                    "string_handler" => {
+                        assert_eq!(
+                            input_schema.get("type").and_then(|v| v.as_str()),
+                            Some("string")
+                        );
+                        assert!(output_schema.is_some());
+                        assert_eq!(
+                            output_schema.unwrap().get("type").and_then(|v| v.as_str()),
+                            Some("integer")
+                        );
+                    }
+                    "json_handler" => {
+                        #[cfg(feature = "schemars")]
+                        {
+                            let obj = input_schema
+                                .as_object()
+                                .expect("Schema should be an object");
+                            assert!(
+                                obj.contains_key("properties"),
+                                "Json schema should have properties"
+                            );
+                            assert!(obj["properties"]["name"]["type"] == "string");
+                            assert!(obj["properties"]["age"]["type"] == "integer");
+                        }
+                        #[cfg(not(feature = "schemars"))]
+                        assert_eq!(input_schema, &serde_json::json!({}));
+                    }
+                    "complex_handler" => {
+                        #[cfg(feature = "schemars")]
+                        {
+                            let obj = input_schema
+                                .as_object()
+                                .expect("Schema should be an object");
+                            assert!(obj.contains_key("properties") || obj.contains_key("$ref"));
+                            let props = obj.get("properties").or_else(|| obj.get("$ref")).unwrap();
+                            assert!(props.is_object(), "Complex schema should define structure");
+                        }
+                        #[cfg(not(feature = "schemars"))]
+                        assert_eq!(input_schema, &serde_json::json!({}));
+                    }
+                    "empty_output_handler" => {
+                        assert_eq!(
+                            input_schema.get("type").and_then(|v| v.as_str()),
+                            Some("string")
+                        );
+                        // For empty output handler, we don't expect json_schema to be set in output
+                        assert!(
+                            output_schema.is_none(),
+                            "Empty output handler should have json_schema set to None"
+                        );
+                        // Verify that set_content_type_if_empty is set
+                        assert_eq!(output.set_content_type_if_empty, Some(false));
+                    }
+                    _ => unreachable!("Unexpected handler"),
+                }
             }
             "no_input_handler" => {
-                assert_eq!(
-                    input_schema.get("type").and_then(|v| v.as_str()),
-                    Some("null")
+                // For no_input_handler, we don't expect json_schema to be set
+                assert!(
+                    input.json_schema.is_none(),
+                    "No input handler should have json_schema set to None"
                 );
+
+                let output_schema = output
+                    .json_schema
+                    .as_ref()
+                    .expect("Output schema should exist");
+
                 assert_eq!(
                     output_schema.get("type").and_then(|v| v.as_str()),
                     Some("string")
                 );
-            }
-            "json_handler" => {
-                #[cfg(feature = "schemars")]
-                {
-                    let obj = input_schema
-                        .as_object()
-                        .expect("Schema should be an object");
-                    assert!(
-                        obj.contains_key("properties"),
-                        "Json schema should have properties"
-                    );
-                    assert!(obj["properties"]["name"]["type"] == "string");
-                    assert!(obj["properties"]["age"]["type"] == "integer");
-                }
-                #[cfg(not(feature = "schemars"))]
-                assert_eq!(input_schema, &serde_json::json!({}));
-            }
-            "complex_handler" => {
-                #[cfg(feature = "schemars")]
-                {
-                    let obj = input_schema
-                        .as_object()
-                        .expect("Schema should be an object");
-                    assert!(obj.contains_key("properties") || obj.contains_key("$ref"));
-                    let props = obj.get("properties").or_else(|| obj.get("$ref")).unwrap();
-                    assert!(props.is_object(), "Complex schema should define structure");
-                }
-                #[cfg(not(feature = "schemars"))]
-                assert_eq!(input_schema, &serde_json::json!({}));
             }
             _ => unreachable!("Unexpected handler"),
         }

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,0 +1,154 @@
+use restate_sdk::prelude::*;
+use restate_sdk::serde::{Json, WithSchema};
+use restate_sdk::service::Discoverable;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
+
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+struct TestUser {
+    name: String,
+    age: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+struct Person {
+    name: String,
+    age: u32,
+    address: Address,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+struct Address {
+    street: String,
+    city: String,
+}
+
+#[restate_sdk::service]
+trait SchemaTestService {
+    async fn string_handler(input: String) -> HandlerResult<i32>;
+    async fn no_input_handler() -> HandlerResult<String>;
+    async fn json_handler(input: Json<TestUser>) -> HandlerResult<Json<TestUser>>;
+    async fn complex_handler(input: Json<Person>) -> HandlerResult<Json<HashMap<String, Person>>>;
+}
+
+struct SchemaTestServiceImpl;
+
+impl SchemaTestService for SchemaTestServiceImpl {
+    async fn string_handler(&self, _ctx: Context<'_>, _input: String) -> HandlerResult<i32> {
+        Ok(42)
+    }
+    async fn no_input_handler(&self, _ctx: Context<'_>) -> HandlerResult<String> {
+        Ok("No input".to_string())
+    }
+    async fn json_handler(
+        &self,
+        _ctx: Context<'_>,
+        input: Json<TestUser>,
+    ) -> HandlerResult<Json<TestUser>> {
+        Ok(input)
+    }
+    async fn complex_handler(
+        &self,
+        _ctx: Context<'_>,
+        input: Json<Person>,
+    ) -> HandlerResult<Json<HashMap<String, Person>>> {
+        Ok(Json(HashMap::from([("original".to_string(), input.0)])))
+    }
+}
+
+#[test]
+fn schema_discovery_and_validation() {
+    let discovery = ServeSchemaTestService::<SchemaTestServiceImpl>::discover();
+    assert_eq!(discovery.name.to_string(), "SchemaTestService");
+    assert_eq!(discovery.handlers.len(), 4);
+
+    for handler in &discovery.handlers {
+        let input = handler
+            .input
+            .as_ref()
+            .expect("Handler should have input schema");
+        let output = handler
+            .output
+            .as_ref()
+            .expect("Handler should have output schema");
+        let input_schema = input
+            .json_schema
+            .as_ref()
+            .expect("Input schema should exist");
+        let output_schema = output
+            .json_schema
+            .as_ref()
+            .expect("Output schema should exist");
+
+        match handler.name.to_string().as_str() {
+            "string_handler" => {
+                assert_eq!(
+                    input_schema.get("type").and_then(|v| v.as_str()),
+                    Some("string")
+                );
+                assert_eq!(
+                    output_schema.get("type").and_then(|v| v.as_str()),
+                    Some("integer")
+                );
+            }
+            "no_input_handler" => {
+                assert_eq!(
+                    input_schema.get("type").and_then(|v| v.as_str()),
+                    Some("null")
+                );
+                assert_eq!(
+                    output_schema.get("type").and_then(|v| v.as_str()),
+                    Some("string")
+                );
+            }
+            "json_handler" => {
+                #[cfg(feature = "schemars")]
+                {
+                    let obj = input_schema
+                        .as_object()
+                        .expect("Schema should be an object");
+                    assert!(
+                        obj.contains_key("properties"),
+                        "Json schema should have properties"
+                    );
+                    assert!(obj["properties"]["name"]["type"] == "string");
+                    assert!(obj["properties"]["age"]["type"] == "integer");
+                }
+                #[cfg(not(feature = "schemars"))]
+                assert_eq!(input_schema, &serde_json::json!({}));
+            }
+            "complex_handler" => {
+                #[cfg(feature = "schemars")]
+                {
+                    let obj = input_schema
+                        .as_object()
+                        .expect("Schema should be an object");
+                    assert!(obj.contains_key("properties") || obj.contains_key("$ref"));
+                    let props = obj.get("properties").or_else(|| obj.get("$ref")).unwrap();
+                    assert!(props.is_object(), "Complex schema should define structure");
+                }
+                #[cfg(not(feature = "schemars"))]
+                assert_eq!(input_schema, &serde_json::json!({}));
+            }
+            _ => unreachable!("Unexpected handler"),
+        }
+    }
+}
+
+#[test]
+fn schema_generation() {
+    let string_schema = <String as WithSchema>::generate_schema();
+    assert_eq!(string_schema["type"], "string");
+
+    let json_schema = <Json<TestUser> as WithSchema>::generate_schema();
+    #[cfg(feature = "schemars")]
+    assert!(json_schema["properties"]["name"]["type"] == "string");
+    #[cfg(not(feature = "schemars"))]
+    assert_eq!(json_schema, serde_json::json!({}));
+}


### PR DESCRIPTION
- Introduced `WithSchema` trait in `src/serde.rs` to standardize schema generation across types.
- Enabled automatic Json<T> schema generation with `schemars` (1.0.0-alpha.17), behind the `schemars` feature, falling back to minimal {} when disabled (unless `WithSchema` is implemented)
- Modified `macros/src/gen.rs` to always generate schemas.
- Wrote `tests/schema.rs` for testing of schema presence and structure.
- Added `examples/schema.rs` to showcase the `schemars` feature.
- Documented feature in`src/lib.rs`.