### PR TITLE
Refactor Endpoint internals.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,16 @@ tracing-span-filter = ["dep:tracing-subscriber"]
 bytes = "1.10"
 futures = "0.3"
 http = "1.3"
+http-body = "1.0.1"
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1.6", optional = true}
 hyper-util = { version = "0.1", features = ["tokio", "server", "server-graceful", "http2"], optional = true }
 pin-project-lite = "0.2"
 rand = { version = "0.9", optional = true }
-regress = "0.10"
+regress = "=0.10.3"
 restate-sdk-macros = { version = "0.6", path = "macros" }
 restate-sdk-shared-core = { version = "=0.4.0", features = ["request_identity", "sha2_random_seed", "http"] }
-schemars = { version = "1.0.0-alpha.17", optional = true }
+schemars = { version = "1.0.0", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "2.0"

--- a/src/endpoint/builder.rs
+++ b/src/endpoint/builder.rs
@@ -1,0 +1,270 @@
+use crate::endpoint::{BoxedService, Endpoint, EndpointInner, Error};
+use crate::service::{Discoverable, Service};
+use futures::future::BoxFuture;
+use restate_sdk_shared_core::{IdentityVerifier, KeyError};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Various configuration options that can be provided when binding a service
+#[derive(Default, Debug, Clone)]
+pub struct ServiceOptions {
+    pub(crate) metadata: HashMap<String, String>,
+    pub(crate) inactivity_timeout: Option<Duration>,
+    pub(crate) abort_timeout: Option<Duration>,
+    pub(crate) idempotency_retention: Option<Duration>,
+    pub(crate) journal_retention: Option<Duration>,
+    pub(crate) enable_lazy_state: Option<bool>,
+    pub(crate) ingress_private: Option<bool>,
+    pub(crate) handler_options: HashMap<String, HandlerOptions>,
+
+    _priv: (),
+}
+
+impl ServiceOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// This timer guards against stalled invocations. Once it expires, Restate triggers a graceful
+    /// termination by asking the invocation to suspend (which preserves intermediate progress).
+    ///
+    /// The abort_timeout is used to abort the invocation, in case it doesn't react to the request to
+    /// suspend.
+    ///
+    /// This overrides the default inactivity timeout configured in the restate-server for all
+    /// invocations to this service.
+    pub fn inactivity_timeout(mut self, timeout: Duration) -> Self {
+        self.inactivity_timeout = Some(timeout);
+        self
+    }
+
+    /// This timer guards against stalled service/handler invocations that are supposed to terminate. The
+    /// abort timeout is started after the inactivity_timeout has expired and the service/handler
+    /// invocation has been asked to gracefully terminate. Once the timer expires, it will abort the
+    /// service/handler invocation.
+    ///
+    /// This timer potentially *interrupts* user code. If the user code needs longer to gracefully
+    /// terminate, then this value needs to be set accordingly.
+    ///
+    /// This overrides the default abort timeout configured in the restate-server for all invocations to
+    /// this service.
+    pub fn abort_timeout(mut self, timeout: Duration) -> Self {
+        self.abort_timeout = Some(timeout);
+        self
+    }
+
+    /// The retention duration of idempotent requests to this service.
+    pub fn idempotency_retention(mut self, retention: Duration) -> Self {
+        self.idempotency_retention = Some(retention);
+        self
+    }
+
+    /// The journal retention. When set, this applies to all requests to all handlers of this service.
+    ///
+    /// In case the request has an idempotency key, the idempotency_retention caps the journal retention
+    /// time.
+    pub fn journal_retention(mut self, retention: Duration) -> Self {
+        self.journal_retention = Some(retention);
+        self
+    }
+
+    /// When set to `true`, lazy state will be enabled for all invocations to this service. This is
+    /// relevant only for workflows and virtual objects.
+    pub fn enable_lazy_state(mut self, enable: bool) -> Self {
+        self.enable_lazy_state = Some(enable);
+        self
+    }
+
+    /// When set to `true` this service, with all its handlers, cannot be invoked from the restate-server
+    /// HTTP and Kafka ingress, but only from other services.
+    pub fn ingress_private(mut self, private: bool) -> Self {
+        self.ingress_private = Some(private);
+        self
+    }
+
+    /// Custom metadata of this service definition. This metadata is shown on the Admin API when querying the service definition.
+    pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    /// Handler-specific options.
+    ///
+    /// *Note*: If you provide a handler name for a non-existing handler, binding the service will *panic!*.
+    pub fn handler(mut self, handler_name: impl Into<String>, options: HandlerOptions) -> Self {
+        self.handler_options.insert(handler_name.into(), options);
+        self
+    }
+}
+
+/// Various configuration options that can be provided when binding a service handler
+#[derive(Default, Debug, Clone)]
+pub struct HandlerOptions {
+    pub(crate) metadata: HashMap<String, String>,
+    pub(crate) inactivity_timeout: Option<Duration>,
+    pub(crate) abort_timeout: Option<Duration>,
+    pub(crate) idempotency_retention: Option<Duration>,
+    pub(crate) workflow_retention: Option<Duration>,
+    pub(crate) journal_retention: Option<Duration>,
+    pub(crate) ingress_private: Option<bool>,
+    pub(crate) enable_lazy_state: Option<bool>,
+
+    _priv: (),
+}
+
+impl HandlerOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Custom metadata of this handler definition. This metadata is shown on the Admin API when querying the service/handler definition.
+    pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    /// This timer guards against stalled invocations. Once it expires, Restate triggers a graceful
+    /// termination by asking the invocation to suspend (which preserves intermediate progress).
+    ///
+    /// The abort_timeout is used to abort the invocation, in case it doesn't react to the request to
+    /// suspend.
+    ///
+    /// This overrides the inactivity timeout set for the service and the default set in restate-server.
+    pub fn inactivity_timeout(mut self, timeout: Duration) -> Self {
+        self.inactivity_timeout = Some(timeout);
+        self
+    }
+
+    /// This timer guards against stalled invocations that are supposed to terminate. The abort timeout
+    /// is started after the inactivity_timeout has expired and the invocation has been asked to
+    /// gracefully terminate. Once the timer expires, it will abort the invocation.
+    ///
+    /// This timer potentially *interrupts* user code. If the user code needs longer to gracefully
+    /// terminate, then this value needs to be set accordingly.
+    ///
+    /// This overrides the abort timeout set for the service and the default set in restate-server.
+    pub fn abort_timeout(mut self, timeout: Duration) -> Self {
+        self.abort_timeout = Some(timeout);
+        self
+    }
+
+    /// The retention duration of idempotent requests to this service.
+    pub fn idempotency_retention(mut self, retention: Duration) -> Self {
+        self.idempotency_retention = Some(retention);
+        self
+    }
+
+    /// The retention duration for this workflow handler.
+    pub fn workflow_retention(mut self, retention: Duration) -> Self {
+        self.workflow_retention = Some(retention);
+        self
+    }
+
+    /// The journal retention for invocations to this handler.
+    ///
+    /// In case the request has an idempotency key, the idempotency_retention caps the journal retention
+    /// time.
+    pub fn journal_retention(mut self, retention: Duration) -> Self {
+        self.journal_retention = Some(retention);
+        self
+    }
+
+    /// When set to `true` this handler cannot be invoked from the restate-server HTTP and Kafka ingress,
+    /// but only from other services.
+    pub fn ingress_private(mut self, private: bool) -> Self {
+        self.ingress_private = Some(private);
+        self
+    }
+
+    /// When set to `true`, lazy state will be enabled for all invocations to this handler. This is
+    /// relevant only for workflows and virtual objects.
+    pub fn enable_lazy_state(mut self, enable: bool) -> Self {
+        self.enable_lazy_state = Some(enable);
+        self
+    }
+}
+
+/// Builder for [`Endpoint`]
+pub struct Builder {
+    svcs: HashMap<String, BoxedService>,
+    discovery: crate::discovery::Endpoint,
+    identity_verifier: IdentityVerifier,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            svcs: Default::default(),
+            discovery: crate::discovery::Endpoint {
+                max_protocol_version: 5,
+                min_protocol_version: 5,
+                protocol_mode: Some(crate::discovery::ProtocolMode::BidiStream),
+                services: vec![],
+            },
+            identity_verifier: Default::default(),
+        }
+    }
+}
+
+impl Builder {
+    /// Create a new builder for [`Endpoint`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a [`Service`] to this endpoint.
+    ///
+    /// When using the [`service`](macro@crate::service), [`object`](macro@crate::object) or [`workflow`](macro@crate::workflow) macros,
+    /// you need to pass the result of the `serve` method.
+    pub fn bind<
+        S: Service<Future = BoxFuture<'static, Result<(), Error>>>
+            + Discoverable
+            + Send
+            + Sync
+            + 'static,
+    >(
+        self,
+        s: S,
+    ) -> Self {
+        self.bind_with_options(s, ServiceOptions::default())
+    }
+
+    /// Like [`bind`], but providing options
+    pub fn bind_with_options<
+        S: Service<Future = BoxFuture<'static, Result<(), Error>>>
+            + Discoverable
+            + Send
+            + Sync
+            + 'static,
+    >(
+        mut self,
+        s: S,
+        service_options: ServiceOptions,
+    ) -> Self {
+        // Discover and apply options
+        let mut service_metadata = S::discover();
+        service_metadata.apply_options(service_options);
+
+        let boxed_service = BoxedService::new(s);
+        self.svcs
+            .insert(service_metadata.name.to_string(), boxed_service);
+        self.discovery.services.push(service_metadata);
+        self
+    }
+
+    /// Add identity key, e.g. `publickeyv1_ChjENKeMvCtRnqG2mrBK1HmPKufgFUc98K8B3ononQvp`.
+    pub fn identity_key(mut self, key: &str) -> Result<Self, KeyError> {
+        self.identity_verifier = self.identity_verifier.with_key(key)?;
+        Ok(self)
+    }
+
+    /// Build the [`Endpoint`].
+    pub fn build(self) -> Endpoint {
+        Endpoint(Arc::new(EndpointInner {
+            svcs: self.svcs,
+            discovery: self.discovery,
+            identity_verifier: self.identity_verifier,
+        }))
+    }
+}

--- a/src/endpoint/builder.rs
+++ b/src/endpoint/builder.rs
@@ -186,25 +186,11 @@ impl HandlerOptions {
 }
 
 /// Builder for [`Endpoint`]
+#[derive(Default)]
 pub struct Builder {
     svcs: HashMap<String, BoxedService>,
-    discovery: crate::discovery::Endpoint,
+    discovery_services: Vec<crate::discovery::Service>,
     identity_verifier: IdentityVerifier,
-}
-
-impl Default for Builder {
-    fn default() -> Self {
-        Self {
-            svcs: Default::default(),
-            discovery: crate::discovery::Endpoint {
-                max_protocol_version: 5,
-                min_protocol_version: 5,
-                protocol_mode: Some(crate::discovery::ProtocolMode::BidiStream),
-                services: vec![],
-            },
-            identity_verifier: Default::default(),
-        }
-    }
 }
 
 impl Builder {
@@ -249,7 +235,7 @@ impl Builder {
         let boxed_service = BoxedService::new(s);
         self.svcs
             .insert(service_metadata.name.to_string(), boxed_service);
-        self.discovery.services.push(service_metadata);
+        self.discovery_services.push(service_metadata);
         self
     }
 
@@ -263,7 +249,7 @@ impl Builder {
     pub fn build(self) -> Endpoint {
         Endpoint(Arc::new(EndpointInner {
             svcs: self.svcs,
-            discovery: self.discovery,
+            discovery_services: self.discovery_services,
             identity_verifier: self.identity_verifier,
         }))
     }

--- a/src/hyper.rs
+++ b/src/hyper.rs
@@ -1,7 +1,7 @@
 //! Hyper integration.
 
 use crate::endpoint;
-use crate::endpoint::Endpoint;
+use crate::endpoint::{Endpoint, HandleOptions, ProtocolMode};
 
 use http::{Request, Response};
 use hyper::body::Incoming;
@@ -24,6 +24,11 @@ impl Service<Request<Incoming>> for HyperEndpoint {
     type Future = Ready<Result<Self::Response, Self::Error>>;
 
     fn call(&self, req: Request<Incoming>) -> Self::Future {
-        ready(self.0.handle(req))
+        ready(self.0.handle_with_options(
+            req,
+            HandleOptions {
+                protocol_mode: ProtocolMode::BidiStream,
+            },
+        ))
     }
 }

--- a/src/hyper.rs
+++ b/src/hyper.rs
@@ -1,28 +1,12 @@
 //! Hyper integration.
 
 use crate::endpoint;
-use crate::endpoint::{Endpoint, InputReceiver, OutputSender};
-use bytes::Bytes;
-use futures::future::BoxFuture;
-use futures::{FutureExt, TryStreamExt};
-use http::header::CONTENT_TYPE;
-use http::{response, HeaderName, HeaderValue, Request, Response};
-use http_body_util::{BodyExt, Either, Full};
-use hyper::body::{Body, Frame, Incoming};
-use hyper::service::Service;
-use restate_sdk_shared_core::Header;
-use std::convert::Infallible;
-use std::future::{ready, Ready};
-use std::ops::Deref;
-use std::pin::Pin;
-use std::task::{ready, Context, Poll};
-use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use crate::endpoint::Endpoint;
 
-#[allow(clippy::declare_interior_mutable_const)]
-const X_RESTATE_SERVER: HeaderName = HeaderName::from_static("x-restate-server");
-const X_RESTATE_SERVER_VALUE: HeaderValue =
-    HeaderValue::from_static(concat!("restate-sdk-rust/", env!("CARGO_PKG_VERSION")));
+use http::{Request, Response};
+use hyper::body::Incoming;
+use hyper::service::Service;
+use std::future::{ready, Ready};
 
 /// Wraps [`Endpoint`] to implement hyper [`Service`].
 #[derive(Clone)]
@@ -35,117 +19,11 @@ impl HyperEndpoint {
 }
 
 impl Service<Request<Incoming>> for HyperEndpoint {
-    type Response = Response<Either<Full<Bytes>, BidiStreamRunner>>;
+    type Response = Response<endpoint::ResponseBody>;
     type Error = endpoint::Error;
     type Future = Ready<Result<Self::Response, Self::Error>>;
 
     fn call(&self, req: Request<Incoming>) -> Self::Future {
-        let (parts, body) = req.into_parts();
-        let endpoint_response = match self.0.resolve(parts.uri.path(), parts.headers) {
-            Ok(res) => res,
-            Err(err) => {
-                debug!("Error when trying to handle incoming request: {err}");
-                return ready(Ok(Response::builder()
-                    .status(err.status_code())
-                    .header(CONTENT_TYPE, "text/plain")
-                    .header(X_RESTATE_SERVER, X_RESTATE_SERVER_VALUE)
-                    .body(Either::Left(Full::new(Bytes::from(err.to_string()))))
-                    .expect("Headers should be valid")));
-            }
-        };
-
-        match endpoint_response {
-            endpoint::Response::ReplyNow {
-                status_code,
-                headers,
-                body,
-            } => ready(Ok(response_builder_from_response_head(
-                status_code,
-                headers,
-            )
-            .body(Either::Left(Full::new(body)))
-            .expect("Headers should be valid"))),
-            endpoint::Response::BidiStream {
-                status_code,
-                headers,
-                handler,
-            } => {
-                let input_receiver =
-                    InputReceiver::from_stream(body.into_data_stream().map_err(|e| e.into()));
-
-                let (output_tx, output_rx) = mpsc::unbounded_channel();
-                let output_sender = OutputSender::from_channel(output_tx);
-
-                let handler_fut = Box::pin(handler.handle(input_receiver, output_sender));
-
-                ready(Ok(response_builder_from_response_head(
-                    status_code,
-                    headers,
-                )
-                .body(Either::Right(BidiStreamRunner {
-                    fut: Some(handler_fut),
-                    output_rx,
-                    end_stream: false,
-                }))
-                .expect("Headers should be valid")))
-            }
-        }
-    }
-}
-
-fn response_builder_from_response_head(
-    status_code: u16,
-    headers: Vec<Header>,
-) -> response::Builder {
-    let mut response_builder = Response::builder()
-        .status(status_code)
-        .header(X_RESTATE_SERVER, X_RESTATE_SERVER_VALUE);
-
-    for header in headers {
-        response_builder = response_builder.header(header.key.deref(), header.value.deref());
-    }
-
-    response_builder
-}
-
-pub struct BidiStreamRunner {
-    fut: Option<BoxFuture<'static, Result<(), endpoint::Error>>>,
-    output_rx: mpsc::UnboundedReceiver<Bytes>,
-    end_stream: bool,
-}
-
-impl Body for BidiStreamRunner {
-    type Data = Bytes;
-    type Error = Infallible;
-
-    fn poll_frame(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        // First try to consume the runner future
-        if let Some(mut fut) = self.fut.take() {
-            match fut.poll_unpin(cx) {
-                Poll::Ready(res) => {
-                    if let Err(e) = res {
-                        warn!("Handler failure: {e:?}")
-                    }
-                    self.output_rx.close();
-                }
-                Poll::Pending => {
-                    self.fut = Some(fut);
-                }
-            }
-        }
-
-        if let Some(out) = ready!(self.output_rx.poll_recv(cx)) {
-            Poll::Ready(Some(Ok(Frame::data(out))))
-        } else {
-            self.end_stream = true;
-            Poll::Ready(None)
-        }
-    }
-
-    fn is_end_stream(&self) -> bool {
-        self.end_stream
+        ready(self.0.handle(req))
     }
 }


### PR DESCRIPTION
It's ok to depend on `http` crate. This reduces the number of additional abstractions needed.