### PR TITLE
Bump shared core to 0.7.1 and update outdated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,44 +25,44 @@ tracing-span-filter = ["dep:tracing-subscriber"]
 lambda = [ "dep:http-serde", "dep:lambda_runtime", "dep:aws_lambda_events"]
 
 [dependencies]
-bytes = "1.10"
+bytes = "1.11"
 futures = "0.3"
-http = "1.3"
+http = "1.4"
 http-body = "1.0.1"
 http-body-util = { version = "0.1", optional = true }
-hyper = { version = "1.6", optional = true}
+hyper = { version = "1.8", optional = true}
 hyper-util = { version = "0.1", features = ["tokio", "server", "server-graceful", "http2"], optional = true }
 pin-project-lite = "0.2"
-rand = { version = "0.9", optional = true }
-regress = "=0.10.3"
+rand = { version = "0.10", optional = true }
+regress = "0.10"
 restate-sdk-macros = { version = "0.8", path = "macros" }
-restate-sdk-shared-core = { version = "=0.6.0", features = ["request_identity", "sha2_random_seed", "http"] }
-schemars = { version = "1.0.0", optional = true }
+restate-sdk-shared-core = { version = "=0.7.1", features = ["request_identity", "sha2_random_seed", "http"] }
+schemars = { version = "1.2", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "2.0"
-tokio = { version = "1.44", default-features = false, features = ["sync"] }
+tokio = { version = "1.49", default-features = false, features = ["sync"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry"], optional = true }
-uuid = { version = "1.16.0", optional = true }
+uuid = { version = "1.20", optional = true }
 http-serde = { version = "2.1.1", optional = true }
-aws_lambda_events = { version = "0.16.1", optional = true }
-lambda_runtime = { version = "0.14.2", optional = true }
+aws_lambda_events = { version = "1.0", optional = true }
+lambda_runtime = { version = "1.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 trybuild = "1.0"
-reqwest = { version = "0.12", features = ["json"] }
-rand = "0.9"
-schemars = "1.0.0-alpha.17"
+reqwest = { version = "0.13", features = ["json"] }
+rand = "0.10"
+schemars = "1.2"
 
 [build-dependencies]
-jsonptr = "0.5.1"
+jsonptr = "0.7"
 prettyplease = "0.2"
 serde_json = { version = "1.0" }
 syn = "2.0"
-typify = { version = "0.1.0" }
+typify = { version = "0.6" }
 
 [workspace]
 members = ["macros", "test-services", "testcontainers"]

--- a/build.rs
+++ b/build.rs
@@ -46,11 +46,8 @@ fn main() -> std::io::Result<()> {
         .add_root_schema(serde_json::from_value(parsed_content).unwrap())
         .unwrap();
 
-    let contents = format!(
-        "{}\n{}",
-        "use serde::{Deserialize, Serialize};",
-        prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream()).unwrap())
-    );
-
-    std::fs::write(out_dir.join("endpoint_manifest.rs"), contents)
+    std::fs::write(
+        out_dir.join("endpoint_manifest.rs"),
+        prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream()).unwrap()),
+    )
 }

--- a/examples/failures.rs
+++ b/examples/failures.rs
@@ -1,4 +1,4 @@
-use rand::RngCore;
+use rand::Rng;
 use restate_sdk::prelude::*;
 
 #[restate_sdk::service]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -779,13 +779,13 @@ pub trait ContextSideEffects<'ctx>: private::SealedContext<'ctx> {
 
     /// ### Generating random numbers
     ///
-    /// Return a [`rand::Rng`] instance inherently predictable, seeded with [`ContextSideEffects::random_seed`].
+    /// Return a [`rand::RngExt`] instance inherently predictable, seeded with [`ContextSideEffects::random_seed`].
     ///
     /// For example, you can use this to generate a random number:
     ///
     /// ```rust,no_run
     /// # use restate_sdk::prelude::*;
-    /// # use rand::Rng;
+    /// # use rand::RngExt;
     /// async fn rand_generate(mut ctx: Context<'_>) {
     /// let x: u32 = ctx.rand().random();
     /// # }
@@ -815,7 +815,7 @@ pub trait ContextSideEffects<'ctx>: private::SealedContext<'ctx> {
     #[cfg(all(feature = "rand", feature = "uuid"))]
     fn rand_uuid(&mut self) -> uuid::Uuid {
         let rand = private::SealedContext::rand(self);
-        uuid::Uuid::from_u64_pair(rand::RngCore::next_u64(rand), rand::RngCore::next_u64(rand))
+        uuid::Uuid::from_u64_pair(rand::Rng::next_u64(rand), rand::Rng::next_u64(rand))
     }
 }
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -3,6 +3,7 @@
 mod generated {
     #![allow(clippy::clone_on_copy)]
     #![allow(clippy::to_string_trait_impl)]
+    #![allow(clippy::derivable_impls)]
 
     include!(concat!(env!("OUT_DIR"), "/endpoint_manifest.rs"));
 }

--- a/src/endpoint/futures/async_result_poll.rs
+++ b/src/endpoint/futures/async_result_poll.rs
@@ -121,6 +121,7 @@ impl Future for VmAsyncResultPollFuture {
                             return Poll::Ready(Ok(Value::Failure(TerminalFailure {
                                 code: 409,
                                 message: "cancelled".to_string(),
+                                metadata: vec![],
                             })));
                         }
                         Err(e) => {

--- a/src/endpoint/futures/select_poll.rs
+++ b/src/endpoint/futures/select_poll.rs
@@ -124,6 +124,7 @@ impl Future for VmSelectAsyncResultPollFuture {
                             return Poll::Ready(Ok(Err(TerminalFailure {
                                 code: 409,
                                 message: "cancelled".to_string(),
+                                metadata: vec![],
                             }
                             .into())));
                         }

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -333,8 +333,8 @@ impl Endpoint {
             Bytes::from(
                 serde_json::to_string(&crate::discovery::Endpoint {
                     lambda_compression: None,
-                    max_protocol_version: 5,
-                    min_protocol_version: 5,
+                    max_protocol_version: std::num::NonZero::new(5).unwrap(),
+                    min_protocol_version: std::num::NonZero::new(5).unwrap(),
                     protocol_mode: Some(match protocol_mode {
                         ProtocolMode::RequestResponse => {
                             crate::discovery::ProtocolMode::RequestResponse

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -155,6 +155,7 @@ impl From<TerminalError> for TerminalFailure {
         Self {
             code: value.0.code,
             message: value.0.message,
+            metadata: vec![],
         }
     }
 }

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -156,7 +156,9 @@ impl LambdaResponseBuilder {
     }
 
     pub fn body(mut self, body: Bytes) -> Self {
-        self.body = Some(Base64Data(body.into()));
+        let mut data = Base64Data::default();
+        data.0 = body.into();
+        self.body = Some(data);
         self
     }
 

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -9,12 +9,12 @@ rust-version = "1.85.0"
 
 
 [dependencies]
-anyhow = "1.0.95"
-futures = "0.3.31"
-reqwest = { version= "0.12.12", features = ["json"] }
+anyhow = "1.0"
+futures = "0.3"
+reqwest = { version= "0.13", features = ["json"] }
 restate-sdk = { version = "0.8.0", path = "../" }
-serde = "1.0.217"
-testcontainers = { version = "0.23.3", features = ["http_wait"] }
-tokio = "1.43.0"
-tracing = "0.1.41"
-tracing-subscriber = "0.3.19"
+serde = "1.0"
+testcontainers = { version = "0.27", features = ["http_wait"] }
+tokio = "1.49"
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -168,16 +168,16 @@ impl StartedRestateContainer {
         )
         .with_exposed_port(8080.tcp())
         .with_exposed_port(9070.tcp())
-        .with_wait_for(WaitFor::Http(
+        .with_wait_for(WaitFor::Http(Box::new(
             HttpWaitStrategy::new("/restate/health")
                 .with_port(8080.tcp())
                 .with_response_matcher(|res| res.status().is_success()),
-        ))
-        .with_wait_for(WaitFor::Http(
+        )))
+        .with_wait_for(WaitFor::Http(Box::new(
             HttpWaitStrategy::new("/health")
                 .with_port(9070.tcp())
                 .with_response_matcher(|res| res.status().is_success()),
-        ));
+        )));
 
         // Start container
         let container = ContainerRequest::from(image)


### PR DESCRIPTION
## Summary

Addresses #92 — bumps `restate-sdk-shared-core` and other outdated dependencies to their latest versions.

### Dependency changes

| Dependency | Old Version | New Version |
|---|---|---|
| `restate-sdk-shared-core` | `=0.6.0` | `=0.7.1` |
| `aws_lambda_events` | `0.16.1` | `1.0` |
| `lambda_runtime` | `0.14.2` | `1.0` |
| `typify` | `0.1.0` | `0.6` |
| `jsonptr` | `0.5.1` | `0.7` |
| `regress` | `=0.10.3` | `0.10` |
| `rand` | `0.9` | `0.10` |
| `bytes` | `1.10` | `1.11` |
| `http` | `1.3` | `1.4` |
| `hyper` | `1.6` | `1.8` |
| `tokio` | `1.44` | `1.49` |
| `uuid` | `1.16.0` | `1.20` |
| `schemars` | `1.0.0` / `1.0.0-alpha.17` | `1.2` |
| `reqwest` (dev + testcontainers) | `0.12` | `0.13` |
| `testcontainers` | `0.23.3` | `0.27` |

### Breaking changes adapted to

- **shared-core 0.7.1**: `TerminalFailure` gained a `metadata` field; `PayloadOptions` parameter added to `sys_state_get`, `sys_state_set`, `sys_call`, `sys_send`, `sys_complete_awakeable`, `sys_complete_promise`, `sys_write_output`; `notify_error` signature changed
- **typify 0.6**: `TypeSpace::new()` now takes owned `TypeSpaceSettings`; generated code uses `NonZero<u64>` for protocol version fields; added `clippy::derivable_impls` allow
- **aws_lambda_events 1.0**: `Base64Data` is `#[non_exhaustive]` — construct via `Default` and field assignment instead of tuple constructor
- **rand 0.10**: `RngCore` renamed to `Rng`, old `Rng` extension trait renamed to `RngExt`
- **testcontainers 0.27**: `WaitFor::Http` now takes `Box<HttpWaitStrategy>`
- **lambda_runtime 1.0**, **jsonptr 0.7**, **bytes**, **http**, **hyper**, **tokio**, **uuid**, **schemars**, **reqwest**: no code changes needed

Closes #92