### PR TITLE
Prepare v0.9.0 release for bumped MSRV and dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "restate-sdk"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "Restate SDK for Rust"
 license = "MIT"
 repository = "https://github.com/restatedev/sdk-rust"
-rust-version = "1.85.0"
+rust-version = "1.90.0"
 
 [[example]]
 name = "tracing"
@@ -35,8 +35,8 @@ hyper-util = { version = "0.1", features = ["tokio", "server", "server-graceful"
 pin-project-lite = "0.2"
 rand = { version = "0.10", optional = true }
 regress = "0.10"
-restate-sdk-macros = { version = "0.8", path = "macros" }
-restate-sdk-shared-core = { version = "=0.7.1", features = ["request_identity", "sha2_random_seed", "http"] }
+restate-sdk-macros = { version = "0.9", path = "macros" }
+restate-sdk-shared-core = { version = "=0.9.0", features = ["request_identity", "sha2_random_seed", "http"] }
 schemars = { version = "1.2", optional = true }
 serde = "1.0"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ The Rust SDK is currently in active development, and might break across releases
 
 The compatibility with Restate is described in the following table:
 
-| Restate Server\sdk-rust | < 0.4            | 0.4 - 0.5 | 0.6              | 0.7              | 0.8              |
-|-------------------------|------------------|-----------|------------------|------------------|------------------|
-| < 1.3                   | ✅                | ❌         | ❌                | ❌                | ❌                |
-| 1.3                     | ✅                | ✅         | ✅ <sup>(1)</sup> | ✅ <sup>(2)</sup> | ✅ <sup>(2)</sup> |
-| 1.4                     | ✅                | ✅         | ✅                | ✅ <sup>(2)</sup> | ✅ <sup>(2)</sup> |
-| 1.5                     | ⚠ <sup>(3)</sup> | ✅         | ✅                | ✅                | ✅                |
-| 1.6                     | ❌ <sup>(4)</sup> | ✅         | ✅                | ✅                | ✅                |
+| Restate Server\sdk-rust | < 0.4            | 0.4 - 0.5 | 0.6              | 0.7 - 0.9        |
+|-------------------------|------------------|-----------|------------------|------------------|
+| < 1.3                   | ✅                | ❌         | ❌                | ❌                |
+| 1.3                     | ✅                | ✅         | ✅ <sup>(1)</sup> | ✅ <sup>(2)</sup> |
+| 1.4                     | ✅                | ✅         | ✅                | ✅ <sup>(2)</sup> |
+| 1.5                     | ⚠ <sup>(3)</sup> | ✅         | ✅                | ✅                |
+| 1.6                     | ❌ <sup>(4)</sup> | ✅         | ✅                | ✅                |
 
 <sup>(1)</sup> **Note** `bind_with_options` works only from Restate 1.4 onward.
 

--- a/examples/failures.rs
+++ b/examples/failures.rs
@@ -17,7 +17,7 @@ impl FailureExample for FailureExampleImpl {
     async fn do_run(&self, context: Context<'_>) -> Result<(), TerminalError> {
         context
             .run::<_, _, ()>(|| async move {
-                if rand::rng().next_u32() % 4 == 0 {
+                if rand::rng().next_u32().is_multiple_of(4) {
                     Err(TerminalError::new("Failed!!!"))?
                 }
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "restate-sdk-macros"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "Restate SDK for Rust macros"
 license = "MIT"
 repository = "https://github.com/restatedev/sdk-rust"
-rust-version = "1.85.0"
+rust-version = "1.90.0"
 
 [lib]
 proc-macro = true

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -8,7 +8,7 @@ This directory contains release notes for the Restate Rust SDK, organized to tra
 release-notes/
 ├── README.md          # This file
 ├── v0.8.0.md          # Consolidated release notes for v0.8.0
-├── v0.9.0.md          # (future releases follow the same pattern)
+├── v0.9.0.md          # Consolidated release notes for v0.9.0
 └── unreleased/        # Release notes for changes not yet released
     └── *.md           # Individual release note files
 ```

--- a/release-notes/v0.9.0.md
+++ b/release-notes/v0.9.0.md
@@ -1,0 +1,99 @@
+# Restate Rust SDK v0.9.0 Release Notes
+
+## Highlights
+
+- **MSRV raised to 1.90.0** — a downstream dependency silently raised its MSRV, which would cause build failures for users relying on our previously announced MSRV
+- **`#[lazy_state]` handler attribute** — opt into lazy state loading on a per-handler basis
+
+## Table of Contents
+
+- [Breaking Changes](#breaking-changes)
+- [New Features](#new-features)
+
+## Breaking Changes
+
+### Dependency bumps with user-facing API changes
+
+Several dependencies have been bumped. Most are transparent, but the following affect user code:
+
+#### `rand` 0.9 → 0.10
+
+The `rand()` method on context types returns `&mut rand::prelude::StdRng`. In rand 0.10, the trait that provides convenience methods like `.random()` and `.random_range()` was renamed from `Rng` to `RngExt`. If you import this trait, update your code:
+
+```diff
+- use rand::Rng;
++ use rand::RngExt;
+```
+
+Additionally, the low-level trait `RngCore` (providing `next_u32()`, `next_u64()`, `fill_bytes()`) was renamed to `Rng`:
+
+```diff
+- use rand::RngCore;
++ use rand::Rng;
+```
+
+`StdRng` no longer implements `Clone`. If you were cloning the RNG returned by `ctx.rand()`, this is no longer possible.
+
+#### Other dependency bumps (no user-facing changes)
+
+The following dependencies were also bumped but require no changes to user code:
+
+| Dependency | Old | New |
+|---|---|---|
+| `restate-sdk-shared-core` | `0.6.0` | `0.9.0` |
+| `aws_lambda_events` | `0.16.1` | `1.0` |
+| `lambda_runtime` | `0.14.2` | `1.0` |
+| `typify` | `0.1.0` | `0.6` |
+| `jsonptr` | `0.5.1` | `0.7` |
+| `regress` | `0.10.3` | `0.10` |
+| `bytes` | `1.10` | `1.11` |
+| `http` | `1.3` | `1.4` |
+| `hyper` | `1.6` | `1.8` |
+| `tokio` | `1.44` | `1.49` |
+| `uuid` | `1.16.0` | `1.20` |
+| `schemars` | `1.0.0` | `1.2` |
+| `reqwest` (dev) | `0.12` | `0.13` |
+| `testcontainers` | `0.23.3` | `0.27` |
+
+### MSRV raised to 1.90.0
+
+The minimum supported Rust version (MSRV) has been raised from **1.85.0** to **1.90.0**.
+
+This bump was necessary because a downstream dependency raised its own MSRV without announcing it. Without this change, users relying on our previously announced MSRV of 1.85.0 would encounter build failures. Any user building with a toolchain between 1.85.0 and 1.87.x is affected. Rather than pinning to an older version of the dependency, we chose to follow the ecosystem forward.
+
+**Impact on Users:**
+- Projects using a Rust toolchain older than 1.90.0 will fail to compile against this version of the SDK
+- Your own crate's `edition` field does not need to change, but your installed Rust toolchain must be >= 1.90.0
+
+**Migration Guidance:**
+
+Update your Rust toolchain:
+
+```bash
+rustup update stable
+```
+
+Verify your version:
+
+```bash
+rustc --version  # Must be >= 1.90.0
+```
+
+## New Features
+
+### `#[lazy_state]` handler attribute
+
+You can now annotate individual handlers with `#[lazy_state]` to enable lazy state loading for that handler. When enabled, state is fetched on demand rather than eagerly loaded when the handler is invoked.
+
+**Example:**
+
+```rust
+#[restate_sdk::object]
+pub trait MyObject {
+    #[lazy_state]
+    async fn my_handler(name: String) -> Result<String, HandlerError>;
+}
+```
+
+**Related Issues:**
+- PR [#90](https://github.com/restatedev/sdk-rust/pull/90)

--- a/src/endpoint/context.rs
+++ b/src/endpoint/context.rs
@@ -402,7 +402,7 @@ impl ContextInternal {
             .and_then(|input| {
                 inner_lock
                     .vm
-                    .sys_call(target, input, PayloadOptions::stable())
+                    .sys_call(target, input, None, PayloadOptions::stable())
                     .map_err(Into::into)
             });
 
@@ -500,6 +500,7 @@ impl ContextInternal {
                     .expect("Duration since unix epoch cannot fail")
                     + delay
             }),
+            None,
             PayloadOptions::stable(),
         ) {
             Ok(h) => h,
@@ -755,10 +756,10 @@ impl ContextInternal {
         let mut inner_lock = must_lock!(self.inner);
 
         let out = inner_lock.vm.take_output();
-        if let TakeOutputResult::Buffer(b) = out {
-            if !inner_lock.write.send(b) {
-                // Nothing we can do anymore here
-            }
+        if let TakeOutputResult::Buffer(b) = out
+            && !inner_lock.write.send(b)
+        {
+            // Nothing we can do anymore here
         }
     }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -54,10 +54,10 @@ impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Filter<S> for ReplayAware
         if let Some(scope) = cx.event_scope(event) {
             let iterator = scope.from_root();
             for span in iterator {
-                if span.name() == "restate_sdk_endpoint_handle" {
-                    if let Some(replay) = span.extensions().get::<ReplayField>() {
-                        return !replay.0;
-                    }
+                if span.name() == "restate_sdk_endpoint_handle"
+                    && let Some(replay) = span.extensions().get::<ReplayField>()
+                {
+                    return !replay.0;
                 }
             }
         }
@@ -65,24 +65,24 @@ impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Filter<S> for ReplayAware
     }
 
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
-        if let Some(span) = ctx.span(id) {
-            if span.name() == "restate_sdk_endpoint_handle" {
-                let mut visitor = ReplayFieldVisitor(false);
-                attrs.record(&mut visitor);
-                let mut extensions = span.extensions_mut();
-                extensions.replace::<ReplayField>(ReplayField(visitor.0));
-            }
+        if let Some(span) = ctx.span(id)
+            && span.name() == "restate_sdk_endpoint_handle"
+        {
+            let mut visitor = ReplayFieldVisitor(false);
+            attrs.record(&mut visitor);
+            let mut extensions = span.extensions_mut();
+            extensions.replace::<ReplayField>(ReplayField(visitor.0));
         }
     }
 
     fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
-        if let Some(span) = ctx.span(id) {
-            if span.name() == "restate_sdk_endpoint_handle" {
-                let mut visitor = ReplayFieldVisitor(false);
-                values.record(&mut visitor);
-                let mut extensions = span.extensions_mut();
-                extensions.replace::<ReplayField>(ReplayField(visitor.0));
-            }
+        if let Some(span) = ctx.span(id)
+            && span.name() == "restate_sdk_endpoint_handle"
+        {
+            let mut visitor = ReplayFieldVisitor(false);
+            values.record(&mut visitor);
+            let mut extensions = span.extensions_mut();
+            extensions.replace::<ReplayField>(ReplayField(visitor.0));
         }
     }
 }

--- a/test-services/Cargo.toml
+++ b/test-services/Cargo.toml
@@ -3,7 +3,7 @@ name = "test-services"
 version = "0.1.0"
 edition = "2024"
 publish = false
-rust-version = "1.85.0"
+rust-version = "1.90.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "restate-sdk-testcontainers"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "Restate SDK Testcontainers utilities"
 license = "MIT"
 repository = "https://github.com/restatedev/sdk-rust"
-rust-version = "1.85.0"
+rust-version = "1.90.0"
 
 
 [dependencies]
 anyhow = "1.0"
 futures = "0.3"
 reqwest = { version= "0.13", features = ["json"] }
-restate-sdk = { version = "0.8.0", path = "../" }
+restate-sdk = { version = "0.9.0", path = "../" }
 serde = "1.0"
 testcontainers = { version = "0.27", features = ["http_wait"] }
 tokio = "1.49"


### PR DESCRIPTION
## Summary

Create a new minor release (v0.9.0) because the MSRV has been raised from 1.85.0 to 1.90.0.

> **Note:** This PR includes the dependency bump changes from #94. Please merge #94 first, then this PR will only show the release-specific changes.

### Changes

- Bump all crate versions from `0.8.0` to `0.9.0` (`restate-sdk`, `restate-sdk-macros`, `restate-sdk-testcontainers`)
- Raise MSRV from `1.85.0` to `1.90.0` (a downstream dependency silently raised its MSRV, which would cause build failures for users relying on our previously announced MSRV)
- Fix new clippy lints (`collapsible_if`, `manual_is_multiple_of`) introduced in Rust 1.90
- Add release notes (`release-notes/v0.9.0.md`) documenting:
  - MSRV bump
  - `#[lazy_state]` handler attribute
  - `rand` 0.9 → 0.10 breaking API changes (`Rng` → `RngExt`, `RngCore` → `Rng`)
  - Full dependency bump table

Fixes #91