### PR TITLE
Drain request input stream before closing response stream (#101)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ schemars = { version = "1.2", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "2.0"
-tokio = { version = "1.49", default-features = false, features = ["sync"] }
+tokio = { version = "1.49", default-features = false, features = ["sync", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry"], optional = true }
 uuid = { version = "1.20", optional = true }

--- a/src/endpoint/context.rs
+++ b/src/endpoint/context.rs
@@ -21,7 +21,7 @@ use restate_sdk_shared_core::{
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::future::{Future, ready};
+use std::future::{Future, poll_fn, ready};
 use std::marker::PhantomData;
 use std::mem;
 use std::pin::Pin;
@@ -761,6 +761,33 @@ impl ContextInternal {
         {
             // Nothing we can do anymore here
         }
+    }
+
+    /// Drain the request input stream to completion.
+    ///
+    /// This ensures we don't close the HTTP/2 response stream before the request
+    /// stream is done, which causes connection errors on proxies like Google Cloud Run.
+    pub(crate) async fn drain_input(&self) -> Result<(), ErrorInner> {
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                let result = poll_fn(|cx| {
+                    let mut inner = must_lock!(self.inner);
+                    inner.read.poll_recv(cx)
+                })
+                .await;
+                match result {
+                    None => return Ok(()),
+                    Some(Ok(_)) => continue,
+                    Some(Err(e)) => return Err(ErrorInner::InputDrain(e)),
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            Err(ErrorInner::InputDrain(
+                "Timed out draining input stream after 60s".into(),
+            ))
+        })
     }
 
     pub(super) fn fail(&self, e: Error) {

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -66,7 +66,8 @@ impl Error {
             | ErrorInner::UnexpectedValueVariantForSyscall { .. }
             | ErrorInner::Deserialization { .. }
             | ErrorInner::Serialization { .. }
-            | ErrorInner::HandlerResult { .. } => 500,
+            | ErrorInner::HandlerResult { .. }
+            | ErrorInner::InputDrain(_) => 500,
             ErrorInner::FieldRequiresMinimumVersion { .. } => 500,
             ErrorInner::BadDiscoveryVersion(_) => 415,
             ErrorInner::Header { .. } | ErrorInner::BadPath { .. } => 400,
@@ -123,6 +124,8 @@ pub(crate) enum ErrorInner {
         #[source]
         err: BoxError,
     },
+    #[error("Error while draining the input stream: {0}")]
+    InputDrain(BoxError),
 }
 
 impl From<CoreError> for Error {
@@ -589,7 +592,15 @@ async fn handle_invocation(
         let user_code_fut = InterceptErrorFuture::new(ctx.clone(), svc.handle(ctx.clone()));
 
         // Wrap it in handler state aware future
-        HandlerStateAwareFuture::new(ctx.clone(), handler_state_rx, user_code_fut).await
+        let result =
+            HandlerStateAwareFuture::new(ctx.clone(), handler_state_rx, user_code_fut).await;
+
+        // Drain the request input stream before returning. This ensures we don't
+        // close the HTTP/2 response stream before the request stream is done,
+        // which causes connection errors on proxies like Google Cloud Run.
+        ctx.drain_input().await?;
+
+        result
     }
     .instrument(span)
     .await


### PR DESCRIPTION
Ensure the HTTP/2 request stream is fully consumed before the response stream is closed, preventing connection errors on proxies like Google Cloud Run.

This closes #101.