### PR TITLE
Add DurableFuturesUnordered

### DIFF
--- a/examples/fan_out.rs
+++ b/examples/fan_out.rs
@@ -21,7 +21,7 @@ struct FanOutImpl;
 
 impl FanOut for FanOutImpl {
     async fn fan_out(&self, ctx: Context<'_>) -> Result<String, TerminalError> {
-        let labels = vec!["fast", "medium", "slow"];
+        let labels = ["fast", "medium", "slow"];
 
         // Fan out: create a dynamic number of durable futures
         let mut futures = DurableFuturesUnordered::new();

--- a/examples/fan_out.rs
+++ b/examples/fan_out.rs
@@ -2,7 +2,7 @@ use restate_sdk::prelude::*;
 use std::time::Duration;
 
 /// This example shows how to fan out multiple calls and process results as they complete,
-/// using [`select_any`] for dynamic concurrent operations.
+/// using [`DurableFuturesUnordered`] for dynamic concurrent operations.
 ///
 /// The `fan_out` handler spawns multiple sleep timers and collects results as they complete,
 /// similar to how you'd use `FuturesUnordered` in regular async Rust.
@@ -21,22 +21,22 @@ struct FanOutImpl;
 
 impl FanOut for FanOutImpl {
     async fn fan_out(&self, ctx: Context<'_>) -> Result<String, TerminalError> {
-        // Fan out: create a dynamic number of durable futures
-        let mut futures = vec![
-            ctx.sleep(Duration::from_secs(3)),
-            ctx.sleep(Duration::from_secs(1)),
-            ctx.sleep(Duration::from_secs(2)),
-        ];
+        let labels = vec!["fast", "medium", "slow"];
 
-        // Process all results as they complete (like FuturesUnordered)
+        // Fan out: create a dynamic number of durable futures
+        let mut futures = DurableFuturesUnordered::new();
+        futures.push(ctx.sleep(Duration::from_secs(1)));
+        futures.push(ctx.sleep(Duration::from_secs(2)));
+        futures.push(ctx.sleep(Duration::from_secs(3)));
+
+        // Process results as they complete — index tells you which future finished
         let mut completion_order = Vec::new();
-        while !futures.is_empty() {
-            let (index, result) = select_any(&mut futures).await?;
+        while let Some((index, result)) = futures.next().await? {
             result?;
-            completion_order.push(index);
+            completion_order.push(labels[index]);
         }
 
-        Ok(format!("Completed in order: {:?}", completion_order))
+        Ok(format!("Completed in order: {completion_order:?}"))
     }
 }
 

--- a/examples/fan_out.rs
+++ b/examples/fan_out.rs
@@ -1,0 +1,49 @@
+use restate_sdk::prelude::*;
+use std::time::Duration;
+
+/// This example shows how to fan out multiple calls and process results as they complete,
+/// using [`select_any`] for dynamic concurrent operations.
+///
+/// The `fan_out` handler spawns multiple sleep timers and collects results as they complete,
+/// similar to how you'd use `FuturesUnordered` in regular async Rust.
+///
+/// To try it:
+///
+/// ```shell
+/// $ curl -v http://localhost:8080/FanOut/fan_out
+/// ```
+#[restate_sdk::service]
+trait FanOut {
+    async fn fan_out() -> Result<String, TerminalError>;
+}
+
+struct FanOutImpl;
+
+impl FanOut for FanOutImpl {
+    async fn fan_out(&self, ctx: Context<'_>) -> Result<String, TerminalError> {
+        // Fan out: create a dynamic number of durable futures
+        let mut futures = vec![
+            ctx.sleep(Duration::from_secs(3)),
+            ctx.sleep(Duration::from_secs(1)),
+            ctx.sleep(Duration::from_secs(2)),
+        ];
+
+        // Process all results as they complete (like FuturesUnordered)
+        let mut completion_order = Vec::new();
+        while !futures.is_empty() {
+            let (index, result) = select_any(&mut futures).await?;
+            result?;
+            completion_order.push(index);
+        }
+
+        Ok(format!("Completed in order: {:?}", completion_order))
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    HttpServer::new(Endpoint::builder().bind(FanOutImpl.serve()).build())
+        .listen_and_serve("0.0.0.0:9080".parse().unwrap())
+        .await;
+}

--- a/examples/run.rs
+++ b/examples/run.rs
@@ -42,6 +42,6 @@ async fn main() {
             .bind(RunExampleImpl(reqwest::Client::new()).serve())
             .build(),
     )
-    .listen_and_serve("0.0.0.0:9085".parse().unwrap())
+    .listen_and_serve("0.0.0.0:9080".parse().unwrap())
     .await;
 }

--- a/examples/run.rs
+++ b/examples/run.rs
@@ -42,6 +42,6 @@ async fn main() {
             .bind(RunExampleImpl(reqwest::Client::new()).serve())
             .build(),
     )
-    .listen_and_serve("0.0.0.0:9080".parse().unwrap())
+    .listen_and_serve("0.0.0.0:9085".parse().unwrap())
     .await;
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -11,9 +11,11 @@ pub mod macro_support;
 mod request;
 mod run;
 mod select;
+mod select_any;
 
 pub use request::{CallFuture, InvocationHandle, Request, RequestTarget};
 pub use run::{RunClosure, RunFuture, RunRetryPolicy};
+pub use select_any::select_any;
 
 pub type HeaderMap = http::HeaderMap<String>;
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -15,7 +15,7 @@ mod select_any;
 
 pub use request::{CallFuture, InvocationHandle, Request, RequestTarget};
 pub use run::{RunClosure, RunFuture, RunRetryPolicy};
-pub use select_any::select_any;
+pub use select_any::DurableFuturesUnordered;
 
 pub type HeaderMap = http::HeaderMap<String>;
 

--- a/src/context/select_any.rs
+++ b/src/context/select_any.rs
@@ -37,7 +37,10 @@ pub async fn select_any<F>(futures: &mut Vec<F>) -> Result<(usize, F::Output), T
 where
     F: DurableFuture,
 {
-    assert!(!futures.is_empty(), "select_any requires at least one future");
+    assert!(
+        !futures.is_empty(),
+        "select_any requires at least one future"
+    );
 
     let handles: Vec<_> = futures.iter().map(|f| f.handle()).collect();
     let ctx = futures[0].inner_context();

--- a/src/context/select_any.rs
+++ b/src/context/select_any.rs
@@ -1,0 +1,48 @@
+use crate::context::DurableFuture;
+use crate::errors::TerminalError;
+
+/// Awaits the first completed future from a dynamic collection of durable futures,
+/// removing the completed future from the Vec via `swap_remove`.
+///
+/// Returns `Ok((index, output))` where `index` is the position of the completed
+/// future in the Vec *before* removal.
+/// Returns `Err(TerminalError)` if the invocation is cancelled.
+///
+/// # Panics
+///
+/// Panics if `futures` is empty.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use restate_sdk::prelude::*;
+/// # use std::time::Duration;
+/// #
+/// # async fn handle(ctx: Context<'_>) -> Result<(), HandlerError> {
+/// let mut futures = vec![
+///     ctx.sleep(Duration::from_secs(1)),
+///     ctx.sleep(Duration::from_secs(2)),
+///     ctx.sleep(Duration::from_secs(3)),
+/// ];
+///
+/// // Process all results as they complete
+/// while !futures.is_empty() {
+///     let (_index, result) = restate_sdk::select_any(&mut futures).await?;
+///     // process result
+/// }
+/// #    Ok(())
+/// # }
+/// ```
+pub async fn select_any<F>(futures: &mut Vec<F>) -> Result<(usize, F::Output), TerminalError>
+where
+    F: DurableFuture,
+{
+    assert!(!futures.is_empty(), "select_any requires at least one future");
+
+    let handles: Vec<_> = futures.iter().map(|f| f.handle()).collect();
+    let ctx = futures[0].inner_context();
+    let index = ctx.select(handles).await?;
+    let future = futures.swap_remove(index);
+    let output = future.await;
+    Ok((index, output))
+}

--- a/src/context/select_any.rs
+++ b/src/context/select_any.rs
@@ -1,16 +1,12 @@
 use crate::context::DurableFuture;
 use crate::errors::TerminalError;
 
-/// Awaits the first completed future from a dynamic collection of durable futures,
-/// removing the completed future from the Vec via `swap_remove`.
+/// A collection of durable futures that yields results as they complete,
+/// similar to [`futures::stream::FuturesUnordered`].
 ///
-/// Returns `Ok((index, output))` where `index` is the position of the completed
-/// future in the Vec *before* removal.
-/// Returns `Err(TerminalError)` if the invocation is cancelled.
-///
-/// # Panics
-///
-/// Panics if `futures` is empty.
+/// Each future is assigned a stable index when pushed, which is returned
+/// alongside the result from [`next`](Self::next) so you can correlate
+/// outputs with inputs.
 ///
 /// # Example
 ///
@@ -19,33 +15,109 @@ use crate::errors::TerminalError;
 /// # use std::time::Duration;
 /// #
 /// # async fn handle(ctx: Context<'_>) -> Result<(), HandlerError> {
-/// let mut futures = vec![
-///     ctx.sleep(Duration::from_secs(1)),
-///     ctx.sleep(Duration::from_secs(2)),
-///     ctx.sleep(Duration::from_secs(3)),
-/// ];
+/// let labels = vec!["fast", "medium", "slow"];
+/// let durations = vec![1, 2, 3];
 ///
-/// // Process all results as they complete
-/// while !futures.is_empty() {
-///     let (_index, result) = restate_sdk::select_any(&mut futures).await?;
-///     // process result
+/// let mut futures = DurableFuturesUnordered::new();
+/// for secs in &durations {
+///     futures.push(ctx.sleep(Duration::from_secs(*secs)));
+/// }
+///
+/// while let Some((index, result)) = futures.next().await? {
+///     result?;
+///     println!("{} timer done!", labels[index]);
 /// }
 /// #    Ok(())
 /// # }
 /// ```
-pub async fn select_any<F>(futures: &mut Vec<F>) -> Result<(usize, F::Output), TerminalError>
-where
-    F: DurableFuture,
-{
-    assert!(
-        !futures.is_empty(),
-        "select_any requires at least one future"
-    );
+///
+/// You can also collect into it from an iterator:
+///
+/// ```rust,no_run
+/// # use restate_sdk::prelude::*;
+/// # use std::time::Duration;
+/// #
+/// # async fn handle(ctx: Context<'_>) -> Result<(), HandlerError> {
+/// let durations = vec![1, 2, 3];
+/// let mut futures: DurableFuturesUnordered<_> = durations
+///     .iter()
+///     .map(|secs| ctx.sleep(Duration::from_secs(*secs)))
+///     .collect();
+///
+/// while let Some((index, result)) = futures.next().await? {
+///     result?;
+/// }
+/// #    Ok(())
+/// # }
+/// ```
+pub struct DurableFuturesUnordered<F> {
+    futures: Vec<(usize, F)>,
+    next_index: usize,
+}
 
-    let handles: Vec<_> = futures.iter().map(|f| f.handle()).collect();
-    let ctx = futures[0].inner_context();
-    let index = ctx.select(handles).await?;
-    let future = futures.swap_remove(index);
-    let output = future.await;
-    Ok((index, output))
+impl<F> DurableFuturesUnordered<F> {
+    /// Create an empty collection.
+    pub fn new() -> Self {
+        Self {
+            futures: Vec::new(),
+            next_index: 0,
+        }
+    }
+
+    /// Add a durable future to the collection.
+    /// Returns the stable index assigned to this future.
+    pub fn push(&mut self, future: F) -> usize {
+        let index = self.next_index;
+        self.next_index += 1;
+        self.futures.push((index, future));
+        index
+    }
+
+    /// Returns `true` if there are no remaining futures.
+    pub fn is_empty(&self) -> bool {
+        self.futures.is_empty()
+    }
+
+    /// Returns the number of remaining futures.
+    pub fn len(&self) -> usize {
+        self.futures.len()
+    }
+}
+
+impl<F> Default for DurableFuturesUnordered<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<F> FromIterator<F> for DurableFuturesUnordered<F> {
+    fn from_iter<I: IntoIterator<Item = F>>(iter: I) -> Self {
+        let futures: Vec<_> = iter.into_iter().enumerate().collect();
+        let next_index = futures.len();
+        Self {
+            futures,
+            next_index,
+        }
+    }
+}
+
+impl<F: DurableFuture> DurableFuturesUnordered<F> {
+    /// Await the next completed future.
+    ///
+    /// Returns `Ok(None)` if there are no remaining futures.
+    /// Returns `Err(TerminalError)` if the invocation was cancelled.
+    /// Returns `Ok(Some((index, output)))` with the stable index and output
+    /// of the next completed future.
+    pub async fn next(&mut self) -> Result<Option<(usize, F::Output)>, TerminalError> {
+        if self.futures.is_empty() {
+            return Ok(None);
+        }
+
+        let handles: Vec<_> = self.futures.iter().map(|(_, f)| f.handle()).collect();
+        let ctx = self.futures[0].1.inner_context();
+        let pos = ctx.select(handles).await?;
+        let (index, future) = self.futures.swap_remove(pos);
+        let output = future.await;
+        Ok(Some((index, output)))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,6 +506,8 @@ pub use restate_sdk_macros::object;
 /// For more details, check the [`service` macro](macro@crate::service) documentation.
 pub use restate_sdk_macros::workflow;
 
+pub use context::select_any;
+
 /// Prelude contains all the useful imports you need to get started with Restate.
 pub mod prelude {
     #[cfg(feature = "http_server")]
@@ -518,7 +520,7 @@ pub mod prelude {
         CallFuture, Context, ContextAwakeables, ContextClient, ContextPromises, ContextReadState,
         ContextSideEffects, ContextTimers, ContextWriteState, HeaderMap, InvocationHandle,
         ObjectContext, Request, RunFuture, RunRetryPolicy, SharedObjectContext,
-        SharedWorkflowContext, WorkflowContext,
+        SharedWorkflowContext, WorkflowContext, select_any,
     };
     pub use crate::endpoint::{
         Endpoint, HandleOptions, HandlerOptions, ProtocolMode, ServiceOptions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,8 +506,6 @@ pub use restate_sdk_macros::object;
 /// For more details, check the [`service` macro](macro@crate::service) documentation.
 pub use restate_sdk_macros::workflow;
 
-pub use context::select_any;
-
 /// Prelude contains all the useful imports you need to get started with Restate.
 pub mod prelude {
     #[cfg(feature = "http_server")]
@@ -518,9 +516,9 @@ pub mod prelude {
 
     pub use crate::context::{
         CallFuture, Context, ContextAwakeables, ContextClient, ContextPromises, ContextReadState,
-        ContextSideEffects, ContextTimers, ContextWriteState, HeaderMap, InvocationHandle,
-        ObjectContext, Request, RunFuture, RunRetryPolicy, SharedObjectContext,
-        SharedWorkflowContext, WorkflowContext, select_any,
+        ContextSideEffects, ContextTimers, ContextWriteState, DurableFuturesUnordered, HeaderMap,
+        InvocationHandle, ObjectContext, Request, RunFuture, RunRetryPolicy, SharedObjectContext,
+        SharedWorkflowContext, WorkflowContext,
     };
     pub use crate::endpoint::{
         Endpoint, HandleOptions, HandlerOptions, ProtocolMode, ServiceOptions,


### PR DESCRIPTION
Usage example:

```rust
#[restate_sdk::service]
trait FanOut {
    async fn fan_out() -> Result<String, TerminalError>;
}

struct FanOutImpl;

impl FanOut for FanOutImpl {
    async fn fan_out(&self, ctx: Context<'_>) -> Result<String, TerminalError> {
        let labels = vec!["fast", "medium", "slow"];

        // Fan out: create a dynamic number of durable futures
        let mut futures = DurableFuturesUnordered::new();
        futures.push(ctx.sleep(Duration::from_secs(1)));
        futures.push(ctx.sleep(Duration::from_secs(2)));
        futures.push(ctx.sleep(Duration::from_secs(3)));

        // Process results as they complete — index tells you which future finished
        let mut completion_order = Vec::new();
        while let Some((index, result)) = futures.next().await? {
            result?;
            completion_order.push(labels[index]);
        }

        Ok(format!("Completed in order: {completion_order:?}"))
    }
}
```