### PR TITLE
Expose jsonwebtoken crypto backend as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,4 @@ members = ["macros", "test-services", "testcontainers"]
 # TODO: remove this patch and bump the restate-sdk-shared-core version once
 # https://github.com/restatedev/sdk-shared-core/pull/76 is released.
 [patch.crates-io]
-restate-sdk-shared-core = { git = "https://github.com/jackkleeman/sdk-shared-core", branch = "jsonwebtoken-backend-passthrough" }
+restate-sdk-shared-core = { git = "https://github.com/jackkleeman/sdk-shared-core", rev = "2dde4f07fe03b61914283a0521239e77ba12f987" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,6 @@ typify = { version = "0.6" }
 members = ["macros", "test-services", "testcontainers"]
 
 # TODO: remove this patch and bump the restate-sdk-shared-core version once
-# https://github.com/restatedev/sdk-shared-core/pull/XXX is released.
+# https://github.com/restatedev/sdk-shared-core/pull/76 is released.
 [patch.crates-io]
 restate-sdk-shared-core = { git = "https://github.com/jackkleeman/sdk-shared-core", branch = "jsonwebtoken-backend-passthrough" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,15 @@ path = "examples/schema.rs"
 required-features = ["schemars"]
 
 [features]
-default = ["http_server", "rand", "uuid", "tracing-span-filter"]
+default = ["http_server", "rand", "uuid", "tracing-span-filter", "rust_crypto"]
 hyper = ["dep:hyper", "http-body-util", "restate-sdk-shared-core/http"]
 http_server = ["hyper", "hyper/server", "hyper/http2", "hyper-util", "tokio/net", "tokio/signal", "tokio/macros"]
 tracing-span-filter = ["dep:tracing-subscriber"]
 lambda = [ "dep:http-serde", "dep:lambda_runtime", "dep:aws_lambda_events"]
+# jsonwebtoken crypto backend pass-through for request identity verification.
+# Enable exactly one (or call jsonwebtoken's CryptoProvider::install_default yourself).
+rust_crypto = ["restate-sdk-shared-core/rust_crypto"]
+aws_lc_rs = ["restate-sdk-shared-core/aws_lc_rs"]
 
 [dependencies]
 bytes = "1.11"
@@ -66,3 +70,8 @@ typify = { version = "0.6" }
 
 [workspace]
 members = ["macros", "test-services", "testcontainers"]
+
+# TODO: remove this patch and bump the restate-sdk-shared-core version once
+# https://github.com/restatedev/sdk-shared-core/pull/XXX is released.
+[patch.crates-io]
+restate-sdk-shared-core = { git = "https://github.com/jackkleeman/sdk-shared-core", branch = "jsonwebtoken-backend-passthrough" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ pin-project-lite = "0.2"
 rand = { version = "0.10", optional = true }
 regress = "0.10"
 restate-sdk-macros = { version = "0.9", path = "macros" }
-restate-sdk-shared-core = { version = "=0.9.0", features = ["request_identity", "sha2_random_seed", "http"] }
+restate-sdk-shared-core = { version = "=0.10.0", features = ["request_identity", "sha2_random_seed", "http"] }
 schemars = { version = "1.2", optional = true }
 serde = "1.0"
 serde_json = "1.0"
@@ -70,8 +70,3 @@ typify = { version = "0.6" }
 
 [workspace]
 members = ["macros", "test-services", "testcontainers"]
-
-# TODO: remove this patch and bump the restate-sdk-shared-core version once
-# https://github.com/restatedev/sdk-shared-core/pull/76 is released.
-[patch.crates-io]
-restate-sdk-shared-core = { git = "https://github.com/jackkleeman/sdk-shared-core", rev = "2dde4f07fe03b61914283a0521239e77ba12f987" }


### PR DESCRIPTION
`restate-sdk-shared-core`'s `request_identity` feature currently bakes in jsonwebtoken's `rust_crypto` backend. If a consuming workspace has jsonwebtoken with `aws_lc_rs` enabled elsewhere in its graph, Cargo feature unification turns both on and jsonwebtoken's provider auto-detection panics at first use. Setting `default-features = false` on `restate-sdk` doesn't help today because `request_identity` is in the unconditional feature list on the shared-core dependency.

This adds `rust_crypto` and `aws_lc_rs` pass-through features (the same pattern `rustls` / `tokio-rustls` use) and puts `rust_crypto` in the `default` set so out-of-the-box behaviour is unchanged. Consumers that need `aws_lc_rs` can now do:

```toml
restate-sdk = { version = "...", default-features = false, features = ["http_server", "aws_lc_rs"] }
```

or enable neither and call `jsonwebtoken::crypto::CryptoProvider::install_default()` themselves.

**Depends on restatedev/sdk-shared-core#76.** The `[patch.crates-io]` entry pointing at that branch is temporary so CI can build — it must be replaced with a version bump on the `restate-sdk-shared-core` dependency before this merges.