### PR TITLE
refactor: introduce ServiceClient and KeyedClient trait hierarchy

### DIFF
--- a/macros/src/generator.rs
+++ b/macros/src/generator.rs
@@ -280,14 +280,23 @@ impl<'a> ServiceGenerator<'a> {
             ref client_ident,
             // service_ident,
             ref service_ty,
+            restate_name,
             ..
         } = self;
+
+        let service_literal = Literal::string(restate_name);
 
         let key_field = match service_ty {
             ServiceType::Service => quote! {},
             ServiceType::Object | ServiceType::Workflow => quote! {
                 key: String,
             },
+        };
+
+        let service_client_impl = quote! {
+            impl ::restate_sdk::context::ServiceClient for #client_ident<'_> {
+                const SERVICE_NAME: &'static str = #service_literal;
+            }
         };
 
         let into_client_impl = match service_ty {
@@ -301,18 +310,22 @@ impl<'a> ServiceGenerator<'a> {
                 }
             }
             ServiceType::Object => quote! {
-                impl<'ctx> ::restate_sdk::context::IntoObjectClient<'ctx> for #client_ident<'ctx> {
+                impl<'ctx> ::restate_sdk::context::KeyedClient<'ctx> for #client_ident<'ctx> {
                     fn create_client(ctx: &'ctx ::restate_sdk::endpoint::ContextInternal, key: String) -> Self {
                         Self { ctx, key }
                     }
                 }
+
+                impl<'ctx> ::restate_sdk::context::IntoObjectClient<'ctx> for #client_ident<'ctx> {}
             },
             ServiceType::Workflow => quote! {
-                impl<'ctx> ::restate_sdk::context::IntoWorkflowClient<'ctx> for #client_ident<'ctx> {
+                impl<'ctx> ::restate_sdk::context::KeyedClient<'ctx> for #client_ident<'ctx> {
                     fn create_client(ctx: &'ctx ::restate_sdk::endpoint::ContextInternal, key: String) -> Self {
                         Self { ctx, key }
                     }
                 }
+
+                impl<'ctx> ::restate_sdk::context::IntoWorkflowClient<'ctx> for #client_ident<'ctx> {}
             },
         };
 
@@ -323,6 +336,7 @@ impl<'a> ServiceGenerator<'a> {
                 #key_field
             }
 
+            #service_client_impl
             #into_client_impl
         }
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -573,20 +573,26 @@ pub trait ContextClient<'ctx>: private::SealedContext<'ctx> {
     }
 }
 
+/// Base trait for all generated service clients. Provides the service name.
+pub trait ServiceClient {
+    const SERVICE_NAME: &'static str;
+}
+
 /// Trait used by codegen to create the service client.
-pub trait IntoServiceClient<'ctx>: Sized {
+pub trait IntoServiceClient<'ctx>: ServiceClient + Sized {
     fn create_client(ctx: &'ctx ContextInternal) -> Self;
 }
 
-/// Trait used by codegen to use the object client.
-pub trait IntoObjectClient<'ctx>: Sized {
+/// Trait for keyed clients (objects and workflows) that can be constructed with a key.
+pub trait KeyedClient<'ctx>: ServiceClient + Sized {
     fn create_client(ctx: &'ctx ContextInternal, key: String) -> Self;
 }
 
+/// Trait used by codegen to use the object client.
+pub trait IntoObjectClient<'ctx>: KeyedClient<'ctx> {}
+
 /// Trait used by codegen to use the workflow client.
-pub trait IntoWorkflowClient<'ctx>: Sized {
-    fn create_client(ctx: &'ctx ContextInternal, key: String) -> Self;
-}
+pub trait IntoWorkflowClient<'ctx>: KeyedClient<'ctx> {}
 
 impl<'ctx, CTX: private::SealedContext<'ctx>> ContextClient<'ctx> for CTX {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,7 +517,7 @@ pub mod prelude {
     pub use crate::context::{
         CallFuture, Context, ContextAwakeables, ContextClient, ContextPromises, ContextReadState,
         ContextSideEffects, ContextTimers, ContextWriteState, HeaderMap, InvocationHandle,
-        ObjectContext, Request, RunFuture, RunRetryPolicy, SharedObjectContext,
+        ObjectContext, Request, RunFuture, RunRetryPolicy, ServiceClient, SharedObjectContext,
         SharedWorkflowContext, WorkflowContext,
     };
     pub use crate::endpoint::{


### PR DESCRIPTION
## Summary

- Adds `ServiceClient` trait with `const SERVICE_NAME: &'static str` as the base for all generated client types
- Introduces `KeyedClient<'ctx>` trait for objects and workflows (keyed services) with `create_client(ctx, key)`
- `IntoObjectClient` and `IntoWorkflowClient` become marker subtypes of `KeyedClient` for type-safe dispatch
- Macro generates `ServiceClient` impl for all service types (service, object, workflow)

This provides a unified way to access the service name from any generated client, enabling features like link/unlink that need the child service name without duplicating it.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` all pass (no behavioral change, purely additive refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)