### PR TITLE
fix: fully qualify Box::pin in ServiceGenerator

### DIFF
--- a/macros/src/generator.rs
+++ b/macros/src/generator.rs
@@ -146,7 +146,7 @@ impl<'a> ServiceGenerator<'a> {
 
                 fn handle(&self, ctx: ::restate_sdk::endpoint::ContextInternal) -> Self::Future {
                     let service_clone = ::std::sync::Arc::clone(&self.service);
-                    Box::pin(async move {
+                    ::std::boxed::Box::pin(async move {
                         match ctx.handler_name() {
                             #( #match_arms ),*
                             _ => {


### PR DESCRIPTION
Hello 👋

Was playing with a toy sandbox implementation baked by restate, and had a struct named `Box` (terrible name in the rust world, I know). This, however, uncovered an unqualified call to `Box::pin` in the service generator. So this tiny PR fixes that for better macro hygiene.

## Repro

In the examples dir, add a struct named `Box` in any of the files:

```diff
diff --git a/examples/counter.rs b/examples/counter.rs
index 8f85bc8..61a761e 100644
--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,5 +1,7 @@
 use restate_sdk::prelude::*;

+pub struct Box {}
+
 #[restate_sdk::object]
 trait Counter {
     #[shared]
```
and the compiler will complain:

```
~/repos/restate-sdk-rust/examples ❯❯❯ cargo test                                                                                                                                                                                                                                                                                          fix/macro-hygine-box ✱
   Compiling restate-sdk v0.10.0 (/Users/mbassem/repos/restate-sdk-rust)
error[E0599]: no function or associated item named `pin` found for struct `Box` in the current scope
 --> examples/counter.rs:5:1
  |
3 | pub struct Box {}
  | -------------- function or associated item `pin` not found for this struct
4 |
5 | #[restate_sdk::object]
  | ^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `Box`
  |
  = note: this error originates in the attribute macro `restate_sdk::object` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0599`.
error: could not compile `restate-sdk` (example "counter") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

After qualifying the call, it compiles and tests are passing.