### PR TITLE
chore: auto-install cargo-nextest in just test

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ build *flags: (_target-installed target)
 print-target:
     @echo {{ _resolved_target }}
 
-test: (_target-installed target)
+test: (_target-installed target) _nextest-installed
     cargo nextest run {{ _target-option }} --all-features --workspace
 
 doctest:
@@ -80,4 +80,15 @@ _target-installed target:
     set -euo pipefail
     if ! rustup target list --installed |grep -qF '{{ target }}' 2>/dev/null ; then
         rustup target add '{{ target }}'
+    fi
+
+_nextest-installed:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if cargo nextest --version >/dev/null 2>&1; then
+        exit 0
+    fi
+    if ! cargo install cargo-nextest --locked; then
+        echo "Latest cargo-nextest incompatible with current rustc; falling back to 0.9.128"
+        cargo install cargo-nextest --locked --version 0.9.128
     fi


### PR DESCRIPTION
## Summary

- `just verify` calls `cargo nextest run`, but the justfile didn't install `cargo-nextest`, so new contributors hit `error: no such command: nextest` on their first run.
- Adds a `_nextest-installed` recipe (mirroring the existing `_target-installed` pattern) that installs `cargo-nextest` if missing.
- Falls back to `cargo-nextest 0.9.128` when the latest release's MSRV exceeds the toolchain pinned in `rust-toolchain.toml` (currently 1.90.0; latest nextest needs 1.91+).

## Test plan

- [x] Fresh shell without `cargo-nextest` installed: `just verify` triggers install
- [x] Shell with current `cargo-nextest` already installed: `just verify` is a no-op for the install step
- [x] On a host whose rustc is older than the latest nextest's MSRV: fallback to `0.9.128` kicks in