### PR TITLE
Configure services and handlers via attribute arguments

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.90.0"
 proc-macro = true
 
 [dependencies]
+jiff = { version = "0.2", default-features = false, features = ["std"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -20,7 +20,7 @@ mod struct_generator;
 
 use crate::ast::{Object, Service, ServiceType, Workflow};
 use crate::generator::ServiceGenerator;
-use crate::struct_ast::{ServiceArgs, StructService};
+use crate::struct_ast::StructService;
 use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::{Item, parse_macro_input};
@@ -55,7 +55,10 @@ fn dispatch(service_ty: ServiceType, attr: TokenStream, input: TokenStream) -> T
     let item = parse_macro_input!(input as Item);
     match item {
         Item::Impl(item_impl) => {
-            let args = parse_macro_input!(attr as ServiceArgs);
+            let args = match struct_ast::parse_service_args(attr.into(), service_ty) {
+                Ok(args) => args,
+                Err(e) => return e.to_compile_error().into(),
+            };
             match StructService::from_impl(service_ty, args, item_impl) {
                 Ok(svc) => struct_generator::generate(&svc).into(),
                 Err(e) => e.to_compile_error().into(),

--- a/macros/src/struct_ast.rs
+++ b/macros/src/struct_ast.rs
@@ -12,59 +12,330 @@
 //! applied to an inherent `impl` block, with handlers annotated `#[handler]`.
 
 use crate::ast::{ServiceType, extract_handler_result_parameter};
-use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
 use syn::token::Comma;
 use syn::{
     Attribute, Error, Expr, ExprLit, FnArg, Ident, ImplItem, ItemImpl, Lit, Meta, MetaNameValue,
     PatType, Result, ReturnType, Type, Visibility, parse_quote,
 };
 
+/// Configuration options accepted both by the service/object/workflow attribute (as service-wide
+/// defaults) and by the `#[handler]` attribute (as per-handler overrides). Durations are parsed
+/// with `jiff` and converted to milliseconds at macro-expansion time, so codegen only has to splice
+/// integers. Every field is optional; unset fields become `None` in the generated discovery.
+#[derive(Default)]
+pub(crate) struct CommonOptions {
+    pub(crate) inactivity_timeout: Option<u64>,
+    pub(crate) abort_timeout: Option<u64>,
+    pub(crate) journal_retention: Option<u64>,
+    pub(crate) idempotency_retention: Option<u64>,
+    /// Handler-only; rejected on the service attribute (no such field on `discovery::Service`).
+    pub(crate) workflow_completion_retention: Option<u64>,
+    pub(crate) enable_lazy_state: Option<bool>,
+    pub(crate) ingress_private: Option<bool>,
+    pub(crate) retry_policy: RetryPolicyArgs,
+}
+
+/// Parsed `invocation_retry_policy(..)` group.
+#[derive(Default)]
+pub(crate) struct RetryPolicyArgs {
+    pub(crate) initial_interval: Option<u64>,
+    pub(crate) max_interval: Option<u64>,
+    pub(crate) factor: Option<f64>,
+    pub(crate) max_attempts: Option<u64>,
+    pub(crate) on_max_attempts: Option<OnMaxAttempts>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum OnMaxAttempts {
+    Pause,
+    Kill,
+}
+
+/// Where a `CommonOptions` set is being parsed, used to gate level-specific options. The service
+/// level carries the service kind so `workflow_completion_retention` can be restricted to workflows.
+#[derive(Clone, Copy)]
+enum ConfigLevel {
+    Service(ServiceType),
+    Handler,
+}
+
 /// Arguments accepted by the service/object/workflow attribute in the struct API,
-/// e.g. `#[restate_sdk::service(name = "Greeter", client_visibility = "pub(crate)")]`.
+/// e.g. `#[restate_sdk::service(name = "Greeter", client_visibility = "pub(crate)")]` plus any of
+/// the shared [`CommonOptions`].
 #[derive(Default)]
 pub(crate) struct ServiceArgs {
     pub(crate) name: Option<String>,
     pub(crate) vis: Option<Visibility>,
+    pub(crate) options: CommonOptions,
 }
 
-impl Parse for ServiceArgs {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let mut args = ServiceArgs::default();
-        if input.is_empty() {
-            return Ok(args);
+/// Parse the service/object/workflow attribute arguments. Takes the service kind so that
+/// `workflow_completion_retention` can be accepted only on `#[workflow]`.
+pub(crate) fn parse_service_args(
+    tokens: proc_macro2::TokenStream,
+    service_ty: ServiceType,
+) -> Result<ServiceArgs> {
+    use syn::parse::Parser;
+
+    let mut args = ServiceArgs::default();
+    if tokens.is_empty() {
+        return Ok(args);
+    }
+    let metas = Punctuated::<Meta, Comma>::parse_terminated.parse2(tokens)?;
+    for meta in &metas {
+        if apply_common_meta(&mut args.options, meta, ConfigLevel::Service(service_ty))? {
+            continue;
         }
-        let metas = Punctuated::<MetaNameValue, Comma>::parse_terminated(input)?;
-        for meta in metas {
-            let ident = meta.path.require_ident()?;
-            if ident == "name" {
-                args.name = Some(parse_str_lit(&meta.value)?);
-            } else if ident == "client_visibility" {
-                let s = parse_str_lit(&meta.value)?;
-                args.vis = Some(syn::parse_str::<Visibility>(&s)?);
-            } else {
-                return Err(Error::new(
-                    ident.span(),
-                    "unsupported attribute argument; supported arguments are `name` and `client_visibility`",
+        let ident = meta.path().require_ident()?;
+        if ident == "name" {
+            args.name = Some(parse_str_lit(name_value_expr(meta)?)?);
+        } else if ident == "client_visibility" {
+            let s = parse_str_lit(name_value_expr(meta)?)?;
+            args.vis = Some(syn::parse_str::<Visibility>(&s)?);
+        } else {
+            return Err(Error::new_spanned(
+                meta,
+                format!(
+                    "unsupported attribute argument `{ident}`; supported arguments are: \
+                     name, client_visibility, inactivity_timeout, abort_timeout, \
+                     journal_retention, idempotency_retention, lazy_state, ingress_private, \
+                     invocation_retry_policy(..){}",
+                    if service_ty == ServiceType::Workflow {
+                        ", workflow_completion_retention"
+                    } else {
+                        ""
+                    }
+                ),
+            ));
+        }
+    }
+    Ok(args)
+}
+
+/// Match one meta item against the shared configuration options. Returns `Ok(true)` if it matched a
+/// common option (already applied), `Ok(false)` if unrecognized so the caller can handle its own
+/// keys (`name`/`client_visibility`) or raise an error.
+fn apply_common_meta(opts: &mut CommonOptions, meta: &Meta, level: ConfigLevel) -> Result<bool> {
+    let Some(ident) = meta.path().get_ident() else {
+        return Ok(false);
+    };
+    match ident.to_string().as_str() {
+        "inactivity_timeout" => opts.inactivity_timeout = Some(parse_duration_meta(meta)?),
+        "abort_timeout" => opts.abort_timeout = Some(parse_duration_meta(meta)?),
+        "journal_retention" => opts.journal_retention = Some(parse_duration_meta(meta)?),
+        "idempotency_retention" => opts.idempotency_retention = Some(parse_duration_meta(meta)?),
+        // Configured at the workflow level (there is a single `run` handler), even though the
+        // discovery schema carries it on the workflow handler. Rejected elsewhere.
+        "workflow_completion_retention" => match level {
+            ConfigLevel::Service(ServiceType::Workflow) => {
+                opts.workflow_completion_retention = Some(parse_duration_meta(meta)?);
+            }
+            ConfigLevel::Service(_) => {
+                return Err(Error::new_spanned(
+                    meta,
+                    "`workflow_completion_retention` is only valid on `#[workflow]`",
+                ));
+            }
+            ConfigLevel::Handler => {
+                return Err(Error::new_spanned(
+                    meta,
+                    "`workflow_completion_retention` is configured on the `#[workflow]` attribute, \
+                     not on individual handlers",
+                ));
+            }
+        },
+        "lazy_state" => opts.enable_lazy_state = Some(parse_flag_or_bool(meta)?),
+        "ingress_private" => opts.ingress_private = Some(parse_flag_or_bool(meta)?),
+        "invocation_retry_policy" => parse_retry_policy(&mut opts.retry_policy, meta)?,
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn parse_retry_policy(retry: &mut RetryPolicyArgs, meta: &Meta) -> Result<()> {
+    let Meta::List(list) = meta else {
+        return Err(Error::new_spanned(
+            meta,
+            "`invocation_retry_policy` expects a group, e.g. \
+             `invocation_retry_policy(max_attempts = 5, initial_interval = \"100ms\")`",
+        ));
+    };
+    let inner = list.parse_args_with(Punctuated::<MetaNameValue, Comma>::parse_terminated)?;
+    for nv in &inner {
+        let ident = nv.path.require_ident()?;
+        match ident.to_string().as_str() {
+            "initial_interval" => retry.initial_interval = Some(parse_duration_expr(&nv.value)?),
+            "max_interval" => retry.max_interval = Some(parse_duration_expr(&nv.value)?),
+            "factor" => retry.factor = Some(parse_f64(&nv.value)?),
+            "max_attempts" => retry.max_attempts = Some(parse_u64(&nv.value)?),
+            "on_max_attempts" => retry.on_max_attempts = Some(parse_on_max_attempts(&nv.value)?),
+            other => {
+                return Err(Error::new_spanned(
+                    &nv.path,
+                    format!(
+                        "unknown `invocation_retry_policy` option `{other}`; supported options are: \
+                         initial_interval, max_interval, factor, max_attempts, on_max_attempts"
+                    ),
                 ));
             }
         }
-        Ok(args)
+    }
+    Ok(())
+}
+
+/// The value expression of a `key = value` meta.
+fn name_value_expr(meta: &Meta) -> Result<&Expr> {
+    match meta {
+        Meta::NameValue(nv) => Ok(&nv.value),
+        _ => Err(Error::new_spanned(
+            meta,
+            "expected `key = value`, e.g. `inactivity_timeout = \"30s\"`",
+        )),
     }
 }
 
 fn parse_str_lit(expr: &Expr) -> Result<String> {
+    Ok(as_str_lit(expr)?.value())
+}
+
+fn as_str_lit(expr: &Expr) -> Result<syn::LitStr> {
     if let Expr::Lit(ExprLit {
         lit: Lit::Str(s), ..
     }) = expr
     {
-        Ok(s.value())
+        Ok(s.clone())
     } else {
-        Err(Error::new(
-            expr.span(),
-            "expected a string literal, e.g. `name = \"Greeter\"`",
+        Err(Error::new_spanned(expr, "expected a string literal"))
+    }
+}
+
+fn parse_duration_meta(meta: &Meta) -> Result<u64> {
+    parse_duration_expr(name_value_expr(meta)?)
+}
+
+fn parse_duration_expr(expr: &Expr) -> Result<u64> {
+    parse_duration_lit(&as_str_lit(expr)?)
+}
+
+/// Parse a human duration string (jiff's "friendly" format, e.g. `"1 sec"`, `"30s"`, `"5m"`,
+/// `"500ms"`, `"2h"`, `"1 day"`, `"7 days"`) into whole milliseconds.
+///
+/// We parse into a [`jiff::Span`] (rather than `SignedDuration`) so calendar-ish units up to weeks
+/// are accepted, treating days as 24h and weeks as 7 days. Months/years are intentionally rejected
+/// by jiff here: they have no fixed millisecond length without a reference date, so they'd be
+/// ambiguous for a timeout/retention value.
+fn parse_duration_lit(lit: &syn::LitStr) -> Result<u64> {
+    let raw = lit.value();
+    let span: jiff::Span = raw
+        .trim()
+        .parse()
+        .map_err(|e| Error::new(lit.span(), format!("invalid duration {raw:?}: {e}")))?;
+    let ms = span
+        .total((
+            jiff::Unit::Millisecond,
+            jiff::SpanRelativeTo::days_are_24_hours(),
         ))
+        .map_err(|e| Error::new(lit.span(), format!("invalid duration {raw:?}: {e}")))?;
+    if ms < 0.0 {
+        return Err(Error::new(
+            lit.span(),
+            format!("duration {raw:?} must not be negative"),
+        ));
+    }
+    let ms = ms.round();
+    if ms > u64::MAX as f64 {
+        return Err(Error::new(
+            lit.span(),
+            format!("duration {raw:?} is too large to represent in milliseconds"),
+        ));
+    }
+    Ok(ms as u64)
+}
+
+fn parse_flag_or_bool(meta: &Meta) -> Result<bool> {
+    match meta {
+        // Bare flag, e.g. `#[handler(lazy_state)]`.
+        Meta::Path(_) => Ok(true),
+        Meta::NameValue(nv) => {
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Bool(b), ..
+            }) = &nv.value
+            {
+                Ok(b.value)
+            } else {
+                Err(Error::new_spanned(
+                    &nv.value,
+                    "expected a boolean literal `true` or `false`",
+                ))
+            }
+        }
+        Meta::List(_) => Err(Error::new_spanned(
+            meta,
+            "expected a bare flag or `= true`/`= false`",
+        )),
+    }
+}
+
+fn parse_f64(expr: &Expr) -> Result<f64> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Float(f), ..
+        }) => f.base10_parse::<f64>(),
+        Expr::Lit(ExprLit {
+            lit: Lit::Int(i), ..
+        }) => Ok(i.base10_parse::<u64>()? as f64),
+        _ => Err(Error::new_spanned(expr, "expected a number, e.g. `2.0`")),
+    }
+}
+
+fn parse_u64(expr: &Expr) -> Result<u64> {
+    if let Expr::Lit(ExprLit {
+        lit: Lit::Int(i), ..
+    }) = expr
+    {
+        i.base10_parse::<u64>()
+    } else {
+        Err(Error::new_spanned(expr, "expected an integer, e.g. `10`"))
+    }
+}
+
+fn parse_on_max_attempts(expr: &Expr) -> Result<OnMaxAttempts> {
+    let s = as_str_lit(expr)?;
+    match s.value().as_str() {
+        "pause" => Ok(OnMaxAttempts::Pause),
+        "kill" => Ok(OnMaxAttempts::Kill),
+        other => Err(Error::new_spanned(
+            expr,
+            format!(r#"invalid `on_max_attempts` value {other:?}; expected "pause" or "kill""#),
+        )),
+    }
+}
+
+/// Collect leading `///`/`#[doc = ".."]` comments from an item's attributes into a single string,
+/// stripping the conventional leading space and trimming. Returns `None` when there are none.
+fn extract_docs(attrs: &[Attribute]) -> Option<String> {
+    let mut lines: Vec<String> = Vec::new();
+    for attr in attrs {
+        if attr.path().is_ident("doc")
+            && let Meta::NameValue(MetaNameValue {
+                value:
+                    Expr::Lit(ExprLit {
+                        lit: Lit::Str(s), ..
+                    }),
+                ..
+            }) = &attr.meta
+        {
+            let raw = s.value();
+            lines.push(raw.strip_prefix(' ').unwrap_or(&raw).to_string());
+        }
+    }
+    let joined = lines.join("\n");
+    let trimmed = joined.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
     }
 }
 
@@ -80,6 +351,10 @@ pub(crate) struct StructService {
     /// Generics of the impl block (type params, bounds and where-clause), propagated onto every
     /// generated impl and the client.
     pub(crate) generics: syn::Generics,
+    /// Doc-comment on the `impl` block, if any (service-level documentation).
+    pub(crate) documentation: Option<String>,
+    /// Service-wide configuration defaults parsed from the service/object/workflow attribute.
+    pub(crate) options: CommonOptions,
     /// The user's impl block with `#[handler]` attributes stripped, re-emitted verbatim.
     pub(crate) stripped_impl: ItemImpl,
     pub(crate) handlers: Vec<StructHandler>,
@@ -91,6 +366,10 @@ pub(crate) struct StructHandler {
     pub(crate) ident: Ident,
     pub(crate) arg: Option<PatType>,
     pub(crate) output_ok: Type,
+    /// Doc-comment on the handler method, if any.
+    pub(crate) documentation: Option<String>,
+    /// Per-handler configuration parsed from `#[handler(..)]`.
+    pub(crate) options: CommonOptions,
 }
 
 impl StructService {
@@ -118,9 +397,11 @@ impl StructService {
         let generics = item_impl.generics.clone();
         let self_ty = item_impl.self_ty.clone();
         let self_ident = type_last_ident(&self_ty)?;
+        let documentation = extract_docs(&item_impl.attrs);
 
         let restate_name = args.name.unwrap_or_else(|| self_ident.to_string());
         let vis = args.vis.unwrap_or_else(|| parse_quote!(pub));
+        let options = args.options;
 
         let mut handlers = Vec::new();
         for item in &mut item_impl.items {
@@ -128,8 +409,15 @@ impl StructService {
                 && let Some(idx) = find_handler_attr(&f.attrs)
             {
                 let attr = f.attrs.remove(idx);
-                let name_override = read_handler_name(&attr)?;
-                handlers.push(parse_handler(service_ty, f, name_override)?);
+                let (name_override, handler_options) = read_handler_attr(&attr)?;
+                let documentation = extract_docs(&f.attrs);
+                handlers.push(parse_handler(
+                    service_ty,
+                    f,
+                    name_override,
+                    handler_options,
+                    documentation,
+                )?);
             }
         }
 
@@ -147,6 +435,8 @@ impl StructService {
             self_ty,
             self_ident,
             generics,
+            documentation,
+            options,
             stripped_impl: item_impl,
             handlers,
         })
@@ -163,37 +453,50 @@ fn find_handler_attr(attrs: &[Attribute]) -> Option<usize> {
     })
 }
 
-/// Read `name = ".."` from `#[handler(name = "..")]`, if present.
-fn read_handler_name(attr: &Attribute) -> Result<Option<String>> {
+/// Read the optional `name = ".."` override and any [`CommonOptions`] from `#[handler(..)]`.
+fn read_handler_attr(attr: &Attribute) -> Result<(Option<String>, CommonOptions)> {
+    let mut name = None;
+    let mut options = CommonOptions::default();
     match &attr.meta {
-        Meta::Path(_) => Ok(None),
+        Meta::Path(_) => {}
         Meta::List(list) => {
-            let metas =
-                list.parse_args_with(Punctuated::<MetaNameValue, Comma>::parse_terminated)?;
-            let mut name = None;
-            for m in metas {
-                if m.path.require_ident()? == "name" {
-                    name = Some(parse_str_lit(&m.value)?);
+            let metas = list.parse_args_with(Punctuated::<Meta, Comma>::parse_terminated)?;
+            for meta in &metas {
+                if apply_common_meta(&mut options, meta, ConfigLevel::Handler)? {
+                    continue;
+                }
+                let ident = meta.path().require_ident()?;
+                if ident == "name" {
+                    name = Some(parse_str_lit(name_value_expr(meta)?)?);
                 } else {
                     return Err(Error::new_spanned(
-                        &m.path,
-                        "unsupported `#[handler]` argument; the only supported argument is `name`",
+                        meta,
+                        format!(
+                            "unsupported `#[handler]` argument `{ident}`; supported arguments are: \
+                             name, inactivity_timeout, abort_timeout, journal_retention, \
+                             idempotency_retention, lazy_state, ingress_private, \
+                             invocation_retry_policy(..)"
+                        ),
                     ));
                 }
             }
-            Ok(name)
         }
-        Meta::NameValue(_) => Err(Error::new_spanned(
-            attr,
-            "invalid `#[handler]` attribute; use `#[handler]` or `#[handler(name = \"..\")]`",
-        )),
+        Meta::NameValue(_) => {
+            return Err(Error::new_spanned(
+                attr,
+                "invalid `#[handler]` attribute; use `#[handler]` or `#[handler(name = \"..\", ..)]`",
+            ));
+        }
     }
+    Ok((name, options))
 }
 
 fn parse_handler(
     service_ty: ServiceType,
     f: &syn::ImplItemFn,
     name_override: Option<String>,
+    options: CommonOptions,
+    documentation: Option<String>,
 ) -> Result<StructHandler> {
     let sig = &f.sig;
 
@@ -280,6 +583,8 @@ fn parse_handler(
         ident: sig.ident.clone(),
         arg,
         output_ok,
+        documentation,
+        options,
     })
 }
 
@@ -343,5 +648,37 @@ fn type_last_ident(ty: &Type) -> Result<Ident> {
             .map(|seg| seg.ident.clone())
             .ok_or_else(|| Error::new_spanned(ty, "expected a named type")),
         _ => Err(Error::new_spanned(ty, "expected a named type")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proc_macro2::Span;
+
+    fn ms(s: &str) -> u64 {
+        parse_duration_lit(&syn::LitStr::new(s, Span::call_site())).expect("valid duration")
+    }
+
+    #[test]
+    fn friendly_durations_parse_to_ms() {
+        assert_eq!(ms("1 sec"), 1_000);
+        assert_eq!(ms("30s"), 30_000);
+        assert_eq!(ms("500ms"), 500);
+        assert_eq!(ms("5m"), 300_000);
+        assert_eq!(ms("1h"), 3_600_000);
+        assert_eq!(ms("2h"), 7_200_000);
+        assert_eq!(ms("1m 30s"), 90_000);
+        assert_eq!(ms("1 day"), 86_400_000);
+        assert_eq!(ms("7 days"), 604_800_000);
+    }
+
+    #[test]
+    fn invalid_duration_is_rejected() {
+        assert!(
+            parse_duration_lit(&syn::LitStr::new("not-a-duration", Span::call_site())).is_err()
+        );
+        // Months/years have no fixed ms length without a reference date -> rejected.
+        assert!(parse_duration_lit(&syn::LitStr::new("1 month", Span::call_site())).is_err());
     }
 }

--- a/macros/src/struct_generator.rs
+++ b/macros/src/struct_generator.rs
@@ -12,10 +12,57 @@
 //! the same `Service`/`Discoverable`/`IntoServiceDefinition` runtime traits used by the trait API.
 
 use crate::ast::ServiceType;
-use crate::struct_ast::{StructHandler, StructService};
+use crate::struct_ast::{CommonOptions, OnMaxAttempts, StructHandler, StructService};
 use proc_macro2::{Literal, TokenStream as TokenStream2};
 use quote::quote;
 use syn::PatType;
+
+/// `Some(<v>)` if set, else `None`, for a primitive that `quote!` can interpolate directly.
+fn opt_lit<T: quote::ToTokens>(v: Option<T>) -> TokenStream2 {
+    match v {
+        Some(v) => quote! { Some(#v) },
+        None => quote! { None },
+    }
+}
+
+fn opt_doc(doc: &Option<String>) -> TokenStream2 {
+    match doc {
+        Some(d) => quote! { Some(#d.to_string()) },
+        None => quote! { None },
+    }
+}
+
+fn opt_on_max_attempts(v: Option<OnMaxAttempts>) -> TokenStream2 {
+    match v {
+        Some(OnMaxAttempts::Pause) => {
+            quote! { Some(::restate_sdk::discovery::RetryPolicyOnMaxAttempts::Pause) }
+        }
+        Some(OnMaxAttempts::Kill) => {
+            quote! { Some(::restate_sdk::discovery::RetryPolicyOnMaxAttempts::Kill) }
+        }
+        None => quote! { None },
+    }
+}
+
+/// Tokens for the retry-policy fields shared by `discovery::Service` and `discovery::Handler`.
+struct RetryPolicyTokens {
+    initial_interval: TokenStream2,
+    max_interval: TokenStream2,
+    max_attempts: TokenStream2,
+    exponentiation_factor: TokenStream2,
+    on_max_attempts: TokenStream2,
+}
+
+fn retry_policy_tokens(opts: &CommonOptions) -> RetryPolicyTokens {
+    let r = &opts.retry_policy;
+    RetryPolicyTokens {
+        initial_interval: opt_lit(r.initial_interval),
+        max_interval: opt_lit(r.max_interval),
+        max_attempts: opt_lit(r.max_attempts),
+        exponentiation_factor: opt_lit(r.factor),
+        on_max_attempts: opt_on_max_attempts(r.on_max_attempts),
+    }
+}
 
 pub(crate) fn generate(svc: &StructService) -> TokenStream2 {
     let stripped_impl = &svc.stripped_impl;
@@ -150,29 +197,70 @@ fn discovery(svc: &StructService) -> TokenStream2 {
             },
         };
 
+        let opts = &handler.options;
+        let documentation = opt_doc(&handler.documentation);
+        let abort_timeout = opt_lit(opts.abort_timeout);
+        let inactivity_timeout = opt_lit(opts.inactivity_timeout);
+        let journal_retention = opt_lit(opts.journal_retention);
+        let idempotency_retention = opt_lit(opts.idempotency_retention);
+        // `workflow_completion_retention` is configured at the workflow level but lives on the
+        // workflow's (non-shared) `run` handler in the discovery schema.
+        let workflow_completion_retention =
+            if svc.service_ty == ServiceType::Workflow && !handler.is_shared {
+                opt_lit(svc.options.workflow_completion_retention)
+            } else {
+                quote! { None }
+            };
+        let enable_lazy_state = opt_lit(opts.enable_lazy_state);
+        let ingress_private = opt_lit(opts.ingress_private);
+        let retry = retry_policy_tokens(opts);
+        let RetryPolicyTokens {
+            initial_interval,
+            max_interval,
+            max_attempts,
+            exponentiation_factor,
+            on_max_attempts,
+        } = retry;
+
         quote! {
             ::restate_sdk::discovery::Handler {
                 name: ::restate_sdk::discovery::HandlerName::try_from(#handler_literal).expect("Handler name valid"),
                 input: #input_schema,
                 output: #output_schema,
                 ty: #handler_ty,
-                documentation: None,
+                documentation: #documentation,
                 metadata: Default::default(),
-                abort_timeout: None,
-                inactivity_timeout: None,
-                journal_retention: None,
-                idempotency_retention: None,
-                workflow_completion_retention: None,
-                enable_lazy_state: None,
-                ingress_private: None,
-                retry_policy_initial_interval: None,
-                retry_policy_max_interval: None,
-                retry_policy_max_attempts: None,
-                retry_policy_exponentiation_factor: None,
-                retry_policy_on_max_attempts: None,
+                abort_timeout: #abort_timeout,
+                inactivity_timeout: #inactivity_timeout,
+                journal_retention: #journal_retention,
+                idempotency_retention: #idempotency_retention,
+                workflow_completion_retention: #workflow_completion_retention,
+                enable_lazy_state: #enable_lazy_state,
+                ingress_private: #ingress_private,
+                retry_policy_initial_interval: #initial_interval,
+                retry_policy_max_interval: #max_interval,
+                retry_policy_max_attempts: #max_attempts,
+                retry_policy_exponentiation_factor: #exponentiation_factor,
+                retry_policy_on_max_attempts: #on_max_attempts,
             }
         }
     });
+
+    let opts = &svc.options;
+    let documentation = opt_doc(&svc.documentation);
+    let abort_timeout = opt_lit(opts.abort_timeout);
+    let inactivity_timeout = opt_lit(opts.inactivity_timeout);
+    let journal_retention = opt_lit(opts.journal_retention);
+    let idempotency_retention = opt_lit(opts.idempotency_retention);
+    let enable_lazy_state = opt_lit(opts.enable_lazy_state);
+    let ingress_private = opt_lit(opts.ingress_private);
+    let RetryPolicyTokens {
+        initial_interval,
+        max_interval,
+        max_attempts,
+        exponentiation_factor,
+        on_max_attempts,
+    } = retry_policy_tokens(opts);
 
     quote! {
         impl #impl_generics ::restate_sdk::service::Discoverable for #self_ty #where_clause {
@@ -182,19 +270,19 @@ fn discovery(svc: &StructService) -> TokenStream2 {
                     name: ::restate_sdk::discovery::ServiceName::try_from(#service_literal.to_string())
                         .expect("Service name valid"),
                     handlers: vec![#( #handlers ),*],
-                    documentation: None,
+                    documentation: #documentation,
                     metadata: Default::default(),
-                    abort_timeout: None,
-                    inactivity_timeout: None,
-                    journal_retention: None,
-                    idempotency_retention: None,
-                    enable_lazy_state: None,
-                    ingress_private: None,
-                    retry_policy_initial_interval: None,
-                    retry_policy_max_interval: None,
-                    retry_policy_max_attempts: None,
-                    retry_policy_exponentiation_factor: None,
-                    retry_policy_on_max_attempts: None,
+                    abort_timeout: #abort_timeout,
+                    inactivity_timeout: #inactivity_timeout,
+                    journal_retention: #journal_retention,
+                    idempotency_retention: #idempotency_retention,
+                    enable_lazy_state: #enable_lazy_state,
+                    ingress_private: #ingress_private,
+                    retry_policy_initial_interval: #initial_interval,
+                    retry_policy_max_interval: #max_interval,
+                    retry_policy_max_attempts: #max_attempts,
+                    retry_policy_exponentiation_factor: #exponentiation_factor,
+                    retry_policy_on_max_attempts: #on_max_attempts,
                 }
             }
         }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,0 +1,152 @@
+//! # Configuring services and handlers
+//!
+//! Services, virtual objects and workflows — and their individual handlers — are configured through
+//! arguments on the [`#[service]`](macro@crate::service) / [`#[object]`](macro@crate::object) /
+//! [`#[workflow]`](macro@crate::workflow) and [`#[handler]`](macro@crate::handler) attributes.
+//!
+//! Options set on the **service** attribute act as defaults for every handler; the same option set
+//! on a **`#[handler]`** overrides the service-wide default for that one handler.
+//!
+//! ```rust,no_run
+//! use restate_sdk::prelude::*;
+//!
+//! struct MyService;
+//!
+//! #[restate_sdk::service(
+//!     // Service-wide defaults, applied to every handler unless it overrides them.
+//!     inactivity_timeout = "10m",
+//!     abort_timeout = "1m",
+//!     idempotency_retention = "1 day",
+//!     invocation_retry_policy(
+//!         initial_interval = "100ms",
+//!         factor = 2.0,
+//!         max_interval = "3s",
+//!         max_attempts = 10,
+//!         on_max_attempts = "pause",
+//!     ),
+//! )]
+//! impl MyService {
+//!     /// This doc comment becomes the handler's `documentation` in discovery
+//!     /// (surfaced in the Restate UI and the OpenAPI export).
+//!     #[handler(
+//!         // Overrides, only for this handler.
+//!         inactivity_timeout = "30s",
+//!         journal_retention = "7 days",
+//!     )]
+//!     async fn my_handler(&self, _ctx: Context<'_>) -> Result<(), HandlerError> {
+//!         Ok(())
+//!     }
+//! }
+//! ```
+//!
+//! ## Durations
+//!
+//! Every duration-valued option is a string parsed with [jiff]'s "friendly" format, e.g. `"500ms"`,
+//! `"30s"`, `"5m"`, `"2h"`, `"1 day"`, or `"1m 30s"`.
+//!
+//! ## Options
+//!
+//! Available on **both** the service attribute (as defaults) and `#[handler]` (as overrides):
+//!
+//! | Option | Type | Description |
+//! |---|---|---|
+//! | `name` | string | Override the service / handler name registered in Restate. |
+//! | `inactivity_timeout` | duration | How long an invocation may stay in-flight without making progress before Restate asks it to suspend gracefully. |
+//! | `abort_timeout` | duration | How long Restate waits after the inactivity timeout before forcibly aborting the invocation (killing the handler task). |
+//! | `journal_retention` | duration | How long the invocation journal is retained after completion. |
+//! | `idempotency_retention` | duration | How long the result of an idempotent invocation is retained for deduplication. |
+//! | `lazy_state` | bool | Load virtual-object K/V state lazily. Bare `lazy_state` is shorthand for `lazy_state = true`. |
+//! | `ingress_private` | bool | Make the service / handler private, i.e. only callable from other handlers, not directly from ingress. |
+//! | [`invocation_retry_policy(..)`](#invocation-retry-policy) | group | The invocation retry policy — see below. |
+//!
+//! Two options are attribute-specific:
+//!
+//! * `client_visibility = "pub(crate)"` — service attribute only; sets the visibility of the
+//!   generated client (defaults to `pub`).
+//! * `workflow_completion_retention` — `#[workflow]` attribute only (see
+//!   [below](#workflow-completion-retention)).
+//!
+//! ## Invocation retry policy
+//!
+//! `invocation_retry_policy(..)` groups the retry settings for an invocation. Every field is
+//! optional; unset fields fall back to the Restate server defaults (or the service-wide policy, when
+//! set on a handler).
+//!
+//! ```rust,no_run
+//! use restate_sdk::prelude::*;
+//! # struct MyService;
+//! #[restate_sdk::service]
+//! impl MyService {
+//!     #[handler(invocation_retry_policy(
+//!         initial_interval = "100ms", // delay before the first retry
+//!         factor = 2.0,               // multiplier applied to the interval after each attempt
+//!         max_interval = "10s",       // upper bound on the retry interval
+//!         max_attempts = 10,          // give up after this many attempts
+//!         on_max_attempts = "kill",   // "pause" or "kill" the invocation once max_attempts is hit
+//!     ))]
+//!     async fn my_handler(&self, _ctx: Context<'_>) -> Result<(), HandlerError> {
+//!         Ok(())
+//!     }
+//! }
+//! ```
+//!
+//! `on_max_attempts` accepts `"pause"` (suspend the invocation so it can be resumed later) or
+//! `"kill"` (fail it permanently). `factor` accepts an integer or a float.
+//!
+//! ## Workflow completion retention
+//!
+//! For workflows, configure how long the completed workflow's result, K/V state and promises are
+//! retained after the `run` handler finishes with `workflow_completion_retention` — set on the
+//! `#[workflow]` attribute, since a workflow has a single `run` handler:
+//!
+//! ```rust,no_run
+//! use restate_sdk::prelude::*;
+//! # struct MyWorkflow;
+//! #[restate_sdk::workflow(workflow_completion_retention = "3 days")]
+//! impl MyWorkflow {
+//!     #[handler]
+//!     async fn run(&self, _ctx: WorkflowContext<'_>) -> Result<(), HandlerError> {
+//!         Ok(())
+//!     }
+//! }
+//! ```
+//!
+//! ## Configuring in code
+//!
+//! The same options can be applied programmatically at bind time via
+//! [`ServiceDefinition::options`](crate::service::ServiceDefinition::options), which takes a
+//! [`ServiceOptions`](crate::endpoint::ServiceOptions) (with per-handler
+//! [`HandlerOptions`](crate::endpoint::HandlerOptions)) — useful when the values come from your own
+//! configuration rather than being known at compile time. Durations are plain
+//! [`Duration`](std::time::Duration)s, and `on_max_attempts` is chosen via
+//! `retry_policy_pause_on_max_attempts()` / `retry_policy_kill_on_max_attempts()`.
+//!
+//! ```rust,no_run
+//! use restate_sdk::prelude::*;
+//! use std::time::Duration;
+//! # struct MyService;
+//! # #[restate_sdk::service]
+//! # impl MyService {
+//! #     #[handler]
+//! #     async fn my_handler(&self, _ctx: Context<'_>) -> Result<(), HandlerError> { Ok(()) }
+//! # }
+//! let service = MyService
+//!     .into_service_definition()
+//!     .options(
+//!         ServiceOptions::new()
+//!             .inactivity_timeout(Duration::from_secs(30))
+//!             .journal_retention(Duration::from_secs(60 * 60 * 24))
+//!             .retry_policy_initial_interval(Duration::from_millis(100))
+//!             .retry_policy_max_attempts(10)
+//!             .retry_policy_pause_on_max_attempts()
+//!             // override options for a single handler
+//!             .handler(
+//!                 "my_handler",
+//!                 HandlerOptions::new().inactivity_timeout(Duration::from_secs(5)),
+//!             ),
+//!     );
+//!
+//! let endpoint = Endpoint::builder().bind(service).build();
+//! ```
+//!
+//! [jiff]: https://docs.rs/jiff

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! Have a look at the following SDK capabilities:
 //!
 //! - [SDK Overview](#sdk-overview): Overview of the SDK and how to implement services, virtual objects, and workflows.
+//! - [Configuration][crate::configuration]: Configure services, objects, workflows and their handlers — timeouts, retention, private-ness and the invocation retry policy — via attribute arguments.
 //! - [Service Communication][crate::context::ContextClient]: Durable RPC and messaging between services (optionally with a delay).
 //! - [Journaling Results][crate::context::ContextSideEffects]: Persist results in Restate's log to avoid re-execution on retries
 //! - State: [read][crate::context::ContextReadState] and [write](crate::context::ContextWriteState): Store and retrieve state in Restate's key-value store
@@ -195,6 +196,7 @@
 pub mod endpoint;
 pub mod service;
 
+pub mod configuration;
 pub mod context;
 pub mod discovery;
 pub mod errors;

--- a/tests/struct_config.rs
+++ b/tests/struct_config.rs
@@ -1,0 +1,144 @@
+//! Tests that the configuration attributes on the struct-based service API land in the generated
+//! discovery: service-wide defaults, per-handler overrides, the `invocation_retry_policy(..)` group,
+//! and `///` doc-comment capture.
+
+use restate_sdk::discovery::{Handler, RetryPolicyOnMaxAttempts, Service};
+use restate_sdk::prelude::*;
+use restate_sdk::service::Discoverable;
+
+fn handler<'a>(disc: &'a Service, name: &str) -> &'a Handler {
+    disc.handlers
+        .iter()
+        .find(|h| h.name.as_str() == name)
+        .unwrap_or_else(|| panic!("handler {name} not found"))
+}
+
+/// A fully configured service.
+struct ConfiguredService;
+
+#[service(
+    name = "Configured",
+    inactivity_timeout = "30s",
+    abort_timeout = "1m",
+    journal_retention = "1 day",
+    idempotency_retention = "2 days",
+    lazy_state = true,
+    ingress_private = false,
+    invocation_retry_policy(
+        initial_interval = "100ms",
+        max_interval = "10s",
+        factor = 2.0,
+        max_attempts = 5,
+        on_max_attempts = "pause",
+    )
+)]
+impl ConfiguredService {
+    /// Documented, overriding handler.
+    #[handler(
+        inactivity_timeout = "5s",
+        invocation_retry_policy(max_attempts = 3, on_max_attempts = "kill")
+    )]
+    async fn configured(&self, _ctx: Context<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+
+    /// A handler with no config overrides.
+    #[handler]
+    async fn plain(&self, _ctx: Context<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn service_level_options_are_applied() {
+    let disc = <ConfiguredService as Discoverable>::discover();
+
+    assert_eq!(disc.name.to_string(), "Configured");
+    assert_eq!(disc.inactivity_timeout, Some(30_000));
+    assert_eq!(disc.abort_timeout, Some(60_000));
+    assert_eq!(disc.journal_retention, Some(86_400_000));
+    assert_eq!(disc.idempotency_retention, Some(172_800_000));
+    assert_eq!(disc.enable_lazy_state, Some(true));
+    assert_eq!(disc.ingress_private, Some(false));
+
+    assert_eq!(disc.retry_policy_initial_interval, Some(100));
+    assert_eq!(disc.retry_policy_max_interval, Some(10_000));
+    assert_eq!(disc.retry_policy_exponentiation_factor, Some(2.0));
+    assert_eq!(disc.retry_policy_max_attempts, Some(5));
+    assert!(matches!(
+        disc.retry_policy_on_max_attempts,
+        Some(RetryPolicyOnMaxAttempts::Pause)
+    ));
+}
+
+#[test]
+fn handler_level_options_override_and_capture_docs() {
+    let disc = <ConfiguredService as Discoverable>::discover();
+
+    let configured = handler(&disc, "configured");
+    assert_eq!(configured.inactivity_timeout, Some(5_000));
+    assert_eq!(configured.retry_policy_max_attempts, Some(3));
+    assert!(matches!(
+        configured.retry_policy_on_max_attempts,
+        Some(RetryPolicyOnMaxAttempts::Kill)
+    ));
+    assert_eq!(
+        configured.documentation.as_deref(),
+        Some("Documented, overriding handler.")
+    );
+
+    let plain = handler(&disc, "plain");
+    assert_eq!(plain.inactivity_timeout, None);
+    assert_eq!(plain.retry_policy_max_attempts, None);
+    assert_eq!(
+        plain.documentation.as_deref(),
+        Some("A handler with no config overrides.")
+    );
+}
+
+/// A workflow that sets the completion retention at the workflow level; it lands on the `run`
+/// handler in the discovery.
+struct ConfiguredWorkflow;
+
+#[workflow(name = "ConfiguredWf", workflow_completion_retention = "3 days")]
+impl ConfiguredWorkflow {
+    #[handler]
+    async fn run(&self, _ctx: WorkflowContext<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+
+    #[handler]
+    async fn status(&self, _ctx: SharedWorkflowContext<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn workflow_completion_retention_lands_on_run_handler() {
+    let disc = <ConfiguredWorkflow as Discoverable>::discover();
+    // Applied to the main (non-shared) `run` handler...
+    assert_eq!(
+        handler(&disc, "run").workflow_completion_retention,
+        Some(259_200_000)
+    );
+    // ...but not to shared handlers.
+    assert_eq!(handler(&disc, "status").workflow_completion_retention, None);
+}
+
+/// A virtual object with a bare-flag `lazy_state` and no `= true`.
+struct FlagObject;
+
+#[object(name = "FlagObject", lazy_state)]
+impl FlagObject {
+    #[handler(ingress_private)]
+    async fn touch(&self, _ctx: ObjectContext<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn bare_bool_flags_mean_true() {
+    let disc = <FlagObject as Discoverable>::discover();
+    assert_eq!(disc.enable_lazy_state, Some(true));
+    assert_eq!(handler(&disc, "touch").ingress_private, Some(true));
+}

--- a/tests/ui/struct_bad_duration.rs
+++ b/tests/ui/struct_bad_duration.rs
@@ -1,0 +1,14 @@
+use restate_sdk::prelude::*;
+
+struct BadDuration;
+
+// The duration string is not parseable by jiff's friendly format.
+#[service(inactivity_timeout = "not-a-duration")]
+impl BadDuration {
+    #[handler]
+    async fn greet(&self, _ctx: Context<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/tests/ui/struct_bad_duration.stderr
+++ b/tests/ui/struct_bad_duration.stderr
@@ -1,0 +1,5 @@
+error: invalid duration "not-a-duration": failed to parse input in the "friendly" duration format: expected duration to start with a unit value (a decimal integer) after an optional sign, but no integer was found
+ --> tests/ui/struct_bad_duration.rs:6:32
+  |
+6 | #[service(inactivity_timeout = "not-a-duration")]
+  |                                ^^^^^^^^^^^^^^^^

--- a/tests/ui/struct_bad_on_max_attempts.rs
+++ b/tests/ui/struct_bad_on_max_attempts.rs
@@ -1,0 +1,14 @@
+use restate_sdk::prelude::*;
+
+struct BadOnMaxAttempts;
+
+// `on_max_attempts` only accepts "pause" or "kill".
+#[service]
+impl BadOnMaxAttempts {
+    #[handler(invocation_retry_policy(max_attempts = 3, on_max_attempts = "explode"))]
+    async fn greet(&self, _ctx: Context<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/tests/ui/struct_bad_on_max_attempts.stderr
+++ b/tests/ui/struct_bad_on_max_attempts.stderr
@@ -1,0 +1,5 @@
+error: invalid `on_max_attempts` value "explode"; expected "pause" or "kill"
+ --> tests/ui/struct_bad_on_max_attempts.rs:8:75
+  |
+8 |     #[handler(invocation_retry_policy(max_attempts = 3, on_max_attempts = "explode"))]
+  |                                                                           ^^^^^^^^^

--- a/tests/ui/struct_unknown_option.rs
+++ b/tests/ui/struct_unknown_option.rs
@@ -1,0 +1,14 @@
+use restate_sdk::prelude::*;
+
+struct UnknownOption;
+
+// `bogus` is not a recognized handler configuration option.
+#[service]
+impl UnknownOption {
+    #[handler(bogus = "x")]
+    async fn greet(&self, _ctx: Context<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/tests/ui/struct_unknown_option.stderr
+++ b/tests/ui/struct_unknown_option.stderr
@@ -1,0 +1,5 @@
+error: unsupported `#[handler]` argument `bogus`; supported arguments are: name, inactivity_timeout, abort_timeout, journal_retention, idempotency_retention, lazy_state, ingress_private, invocation_retry_policy(..)
+ --> tests/ui/struct_unknown_option.rs:8:15
+  |
+8 |     #[handler(bogus = "x")]
+  |               ^^^^^^^^^^^

--- a/tests/ui/struct_workflow_retention_on_handler.rs
+++ b/tests/ui/struct_workflow_retention_on_handler.rs
@@ -1,0 +1,14 @@
+use restate_sdk::prelude::*;
+
+struct WfRetentionOnHandler;
+
+// `workflow_completion_retention` is configured on the `#[workflow]` attribute, not the handler.
+#[workflow]
+impl WfRetentionOnHandler {
+    #[handler(workflow_completion_retention = "1 day")]
+    async fn run(&self, _ctx: WorkflowContext<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/tests/ui/struct_workflow_retention_on_handler.stderr
+++ b/tests/ui/struct_workflow_retention_on_handler.stderr
@@ -1,0 +1,5 @@
+error: `workflow_completion_retention` is configured on the `#[workflow]` attribute, not on individual handlers
+ --> tests/ui/struct_workflow_retention_on_handler.rs:8:15
+  |
+8 |     #[handler(workflow_completion_retention = "1 day")]
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/struct_workflow_retention_on_service.rs
+++ b/tests/ui/struct_workflow_retention_on_service.rs
@@ -1,0 +1,14 @@
+use restate_sdk::prelude::*;
+
+struct WfRetentionOnService;
+
+// `workflow_completion_retention` is only valid on `#[workflow]`, not `#[service]`/`#[object]`.
+#[service(workflow_completion_retention = "1 day")]
+impl WfRetentionOnService {
+    #[handler]
+    async fn greet(&self, _ctx: Context<'_>) -> HandlerResult<()> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/tests/ui/struct_workflow_retention_on_service.stderr
+++ b/tests/ui/struct_workflow_retention_on_service.stderr
@@ -1,0 +1,5 @@
+error: `workflow_completion_retention` is only valid on `#[workflow]`
+ --> tests/ui/struct_workflow_retention_on_service.rs:6:11
+  |
+6 | #[service(workflow_completion_retention = "1 day")]
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Ports the configuration idea from #97 into the **struct-based service API** (the trait macro is left untouched).

Configuration is provided as key-value arguments directly on the existing `#[service]`/`#[object]`/`#[workflow]` attributes (service-wide defaults) and `#[handler]` attributes (per-handler overrides):

```rust
#[restate_sdk::service(
    inactivity_timeout = "10m",
    idempotency_retention = "1 day",
    invocation_retry_policy(
        initial_interval = "100ms",
        factor = 2.0,
        max_interval = "3s",
        max_attempts = 10,
        on_max_attempts = "pause",
    ),
)]
impl MyService {
    /// This doc comment becomes the handler's `documentation` in discovery.
    #[handler(inactivity_timeout = "30s", journal_retention = "7 days")]
    async fn my_handler(&self, _ctx: Context<'_>) -> Result<(), HandlerError> { Ok(()) }
}
```

### What's supported

On both the service attribute (defaults) and `#[handler]` (overrides): `inactivity_timeout`, `abort_timeout`, `journal_retention`, `idempotency_retention`, `lazy_state`, `ingress_private`, `name`, and the nested `invocation_retry_policy(initial_interval, max_interval, factor, max_attempts, on_max_attempts = "pause" | "kill")`.

- **`workflow_completion_retention`** is set on the `#[workflow]` attribute (a workflow has a single `run` handler); it's emitted onto the workflow's `run` handler in the discovery manifest. Rejected on `#[service]`/`#[object]` and on `#[handler]` with a clear compile error.
- **`///` doc-comments** on the impl block and handler methods are captured into the discovery `documentation` field.
- These values are emitted directly into the generated `discovery::Service`/`Handler` manifest (which previously hardcoded them to `None`).

### Durations

Duration options are strings parsed at macro-expansion time with [jiff](https://docs.rs/jiff)'s "friendly" format — milliseconds up to weeks (days = 24h, weeks = 7 days), e.g. `"500ms"`, `"30s"`, `"5m"`, `"2h"`, `"1 day"`, `"1m 30s"`. Calendar units (months/years) are rejected since they have no fixed length. `jiff` is a compile-time-only dependency of the macros crate (`default-features = false`, no tzdb).

### Docs

Adds a `configuration` documentation page (linked from the crate-level `# Features` section) covering the attribute syntax and configuring programmatically via `ServiceDefinition::options` / `ServiceOptions` / `HandlerOptions`.

### Tests

- `tests/struct_config.rs` — asserts the config lands in the generated discovery (service defaults, handler overrides, retry policy, workflow completion retention, bare-flag bools, doc capture).
- `tests/ui/*` — trybuild failure cases (bad duration, invalid `on_max_attempts`, unknown option, `workflow_completion_retention` misplaced).

Verified: `fmt --check`, `clippy --all-targets --workspace -D warnings`, full test suite incl. the testcontainers e2e, 41 doctests, and `RUSTDOCFLAGS=-D warnings cargo doc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)