### PR TITLE
feat: signals API and id-backed InvocationHandle

### DIFF
--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -1,0 +1,51 @@
+use restate_sdk::prelude::*;
+
+struct SignalExample;
+
+#[restate_sdk::service]
+impl SignalExample {
+    /// Await a signal named "approval" on the current invocation.
+    ///
+    /// Share this invocation's id (`ctx.invocation_id()`) with whoever should approve; they can
+    /// then complete the signal via `approve`/`reject` below.
+    #[handler]
+    async fn await_approval(&self, ctx: Context<'_>) -> Result<String, HandlerError> {
+        println!(
+            "Waiting for approval. Approve with invocation id: {}",
+            ctx.invocation_id()
+        );
+
+        // Suspends until another invocation resolves/rejects the "approval" signal on this
+        // invocation. Works in `select!` too, since it is a durable future.
+        let decision = ctx.signal::<String>("approval").await?;
+
+        Ok(format!("Approved with: {decision}"))
+    }
+
+    /// Resolve the "approval" signal on the target invocation.
+    #[handler]
+    async fn approve(&self, ctx: Context<'_>, invocation_id: String) -> Result<(), HandlerError> {
+        ctx.invocation_handle(invocation_id)
+            .signal("approval")
+            .resolve("looks good".to_string());
+        Ok(())
+    }
+
+    /// Reject the "approval" signal on the target invocation. The awaiting handler observes a
+    /// terminal error.
+    #[handler]
+    async fn reject(&self, ctx: Context<'_>, invocation_id: String) -> Result<(), HandlerError> {
+        ctx.invocation_handle(invocation_id)
+            .signal("approval")
+            .reject(TerminalError::new("rejected"));
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    HttpServer::new(Endpoint::builder().bind(SignalExample).build())
+        .listen_and_serve("0.0.0.0:9080".parse().unwrap())
+        .await;
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -13,7 +13,7 @@ mod run;
 mod select;
 mod select_any;
 
-pub use request::{CallFuture, InvocationHandle, Request, RequestTarget};
+pub use request::{CallFuture, InvocationHandle, Request, RequestTarget, SendHandle, SignalHandle};
 pub use run::{RunClosure, RunFuture, RunRetryPolicy};
 pub use select_any::DurableFuturesUnordered;
 
@@ -477,7 +477,7 @@ pub trait ContextClient<'ctx>: private::SealedContext<'ctx> {
     }
 
     /// Create an [`InvocationHandle`] from an invocation id.
-    fn invocation_handle(&self, invocation_id: String) -> impl InvocationHandle + 'ctx {
+    fn invocation_handle(&self, invocation_id: String) -> InvocationHandle {
         self.inner_context().invocation_handle(invocation_id)
     }
 
@@ -692,6 +692,76 @@ pub trait ContextAwakeables<'ctx>: private::SealedContext<'ctx> {
 }
 
 impl<'ctx, CTX: private::SealedContext<'ctx>> ContextAwakeables<'ctx> for CTX {}
+
+/// # Signals
+///
+/// Signals let invocations communicate with each other. A signal is a named, one-shot
+/// durable promise **scoped to a specific invocation**: a running handler awaits a signal by name,
+/// and any other handler completes it by targeting the awaiter's **invocation id** and the same
+/// **signal name**.
+///
+/// Signals are similar to [awakeables][crate::context::ContextAwakeables], but instead of an
+/// opaque generated identifier you exfiltrate, they are addressed by `(invocation_id, name)`.
+/// The awaiting handler just needs to share its own invocation id (available via
+/// [`Context::invocation_id`]).
+///
+/// ## Awaiting a signal
+///
+/// ```rust,no_run
+/// # use restate_sdk::prelude::*;
+/// # async fn handle(ctx: Context<'_>) -> Result<(), HandlerError> {
+/// // Wait for a named signal on the current invocation
+/// let value = ctx.signal::<String>("my-signal").await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The returned future is a [`DurableFuture`], so it can be combined with other durable futures
+/// using [`crate::select`].
+///
+/// ## Completing a signal
+///
+/// Another handler completes the signal on the target invocation using its
+/// [`InvocationHandle`][crate::context::InvocationHandle]:
+///
+/// ```rust,no_run
+/// # use restate_sdk::prelude::*;
+/// // Resolve the signal with a value
+/// # async fn resolve(ctx: Context<'_>, invocation_id: String) -> Result<(), HandlerError> {
+/// ctx.invocation_handle(invocation_id)
+///     .signal("my-signal")
+///     .resolve("hello".to_string());
+/// # Ok(())
+/// # }
+///
+/// // Or reject it, so the awaiting handler observes a terminal error
+/// # async fn reject(ctx: Context<'_>, invocation_id: String) -> Result<(), HandlerError> {
+/// ctx.invocation_handle(invocation_id)
+///     .signal("my-signal")
+///     .reject(TerminalError::new("my error reason"));
+/// # Ok(())
+/// # }
+/// ```
+///
+/// For more info about serialization of the payload, see [crate::serde].
+///
+/// **Be aware**: Virtual Objects only process a single invocation at a time, so the Virtual Object
+/// will be blocked while waiting on the signal to be completed.
+pub trait ContextSignals<'ctx>: private::SealedContext<'ctx> {
+    /// Wait for a named signal to arrive on the current invocation.
+    ///
+    /// Signals are identified by name and are scoped to the current invocation. Another handler
+    /// can complete this signal via [`InvocationHandle::signal`][crate::context::InvocationHandle::signal],
+    /// specifying this invocation's id (available via [`Context::invocation_id`]) and the same name.
+    fn signal<T: Deserialize + 'static>(
+        &self,
+        name: &str,
+    ) -> impl DurableFuture<Output = Result<T, TerminalError>> + Send + 'ctx {
+        self.inner_context().signal(name)
+    }
+}
+
+impl<'ctx, CTX: private::SealedContext<'ctx>> ContextSignals<'ctx> for CTX {}
 
 /// # Journaling Results
 ///

--- a/src/context/request.rs
+++ b/src/context/request.rs
@@ -3,8 +3,10 @@ use super::DurableFuture;
 use crate::endpoint::ContextInternal;
 use crate::errors::TerminalError;
 use crate::serde::{Deserialize, Serialize};
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use std::fmt;
-use std::future::Future;
+use std::future::{Future, IntoFuture};
 use std::marker::PhantomData;
 use std::time::Duration;
 
@@ -118,7 +120,10 @@ impl<'a, Req, Res> Request<'a, Req, Res> {
     }
 
     /// Send the request to the service, without waiting for the response.
-    pub fn send(self) -> impl InvocationHandle
+    ///
+    /// The request is sent eagerly; you can drop the returned [`SendHandle`] to fire-and-forget,
+    /// or `.await` it to obtain an [`InvocationHandle`] to the newly created invocation.
+    pub fn send(self) -> SendHandle
     where
         Req: Serialize + 'static,
     {
@@ -132,7 +137,9 @@ impl<'a, Req, Res> Request<'a, Req, Res> {
     }
 
     /// Schedule the request to the service, without waiting for the response.
-    pub fn send_after(self, delay: Duration) -> impl InvocationHandle
+    ///
+    /// Same as [`Request::send`], but the invocation is executed after the given `delay`.
+    pub fn send_after(self, delay: Duration) -> SendHandle
     where
         Req: Serialize + 'static,
     {
@@ -146,13 +153,126 @@ impl<'a, Req, Res> Request<'a, Req, Res> {
     }
 }
 
-pub trait InvocationHandle {
-    fn invocation_id(&self) -> impl Future<Output = Result<String, TerminalError>> + Send;
-    fn cancel(&self) -> impl Future<Output = Result<(), TerminalError>> + Send;
+/// A handle to an invocation.
+///
+/// You can obtain an [`InvocationHandle`] in three ways:
+///
+/// * From [`ContextClient::invocation_handle`][crate::context::ContextClient::invocation_handle],
+///   when you already know the invocation id.
+/// * By `.await`-ing the [`SendHandle`] returned by [`Request::send`]/[`Request::send_after`].
+/// * By `.await`-ing [`CallFuture::invocation_handle`].
+///
+/// Once obtained, the invocation id is known synchronously via [`InvocationHandle::invocation_id`].
+pub struct InvocationHandle {
+    ctx: ContextInternal,
+    invocation_id: String,
 }
 
-pub trait CallFuture:
-    DurableFuture<Output = Result<Self::Response, TerminalError>> + InvocationHandle
-{
+impl InvocationHandle {
+    pub(crate) fn new(ctx: ContextInternal, invocation_id: String) -> Self {
+        Self { ctx, invocation_id }
+    }
+
+    /// The invocation id of the target invocation.
+    pub fn invocation_id(&self) -> &str {
+        &self.invocation_id
+    }
+
+    /// Cancel the invocation.
+    pub fn cancel(&self) {
+        self.ctx.cancel_invocation(&self.invocation_id)
+    }
+
+    /// Attach to the invocation, returning a future that resolves with its output/result.
+    pub fn attach<T: Deserialize + 'static>(
+        &self,
+    ) -> impl DurableFuture<Output = Result<T, TerminalError>> + Send + use<T> {
+        self.ctx.attach_invocation(self.invocation_id.clone())
+    }
+
+    /// Get a handle to a named [signal][crate::context::ContextSignals] on this invocation,
+    /// which you can [resolve][SignalHandle::resolve] or [reject][SignalHandle::reject].
+    pub fn signal(&self, name: impl Into<String>) -> SignalHandle {
+        SignalHandle {
+            ctx: self.ctx.clone(),
+            invocation_id: self.invocation_id.clone(),
+            name: name.into(),
+        }
+    }
+}
+
+/// A handle to a named signal on a target invocation, obtained via [`InvocationHandle::signal`].
+///
+/// Use it to complete a signal the target invocation is (or will be) awaiting via
+/// [`ContextSignals::signal`][crate::context::ContextSignals::signal].
+pub struct SignalHandle {
+    ctx: ContextInternal,
+    invocation_id: String,
+    name: String,
+}
+
+impl SignalHandle {
+    /// Resolve the signal with the given value.
+    pub fn resolve<T: Serialize + 'static>(self, value: T) {
+        self.ctx
+            .resolve_signal(&self.invocation_id, &self.name, value)
+    }
+
+    /// Reject the signal. The awaiting handler observes a terminal error.
+    pub fn reject(self, failure: TerminalError) {
+        self.ctx
+            .reject_signal(&self.invocation_id, &self.name, failure)
+    }
+}
+
+/// Handle returned by [`Request::send`]/[`Request::send_after`].
+///
+/// The request is already sent; `.await` this handle to obtain an [`InvocationHandle`] to the
+/// created invocation, or drop it to fire-and-forget.
+pub struct SendHandle {
+    invocation_id_future: BoxFuture<'static, Result<String, TerminalError>>,
+    ctx: ContextInternal,
+}
+
+impl SendHandle {
+    pub(crate) fn new(
+        ctx: ContextInternal,
+        invocation_id_future: BoxFuture<'static, Result<String, TerminalError>>,
+    ) -> Self {
+        Self {
+            invocation_id_future,
+            ctx,
+        }
+    }
+}
+
+impl IntoFuture for SendHandle {
+    type Output = Result<InvocationHandle, TerminalError>;
+    type IntoFuture = BoxFuture<'static, Result<InvocationHandle, TerminalError>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let ctx = self.ctx;
+        async move {
+            let invocation_id = self.invocation_id_future.await?;
+            Ok(InvocationHandle::new(ctx, invocation_id))
+        }
+        .boxed()
+    }
+}
+
+pub trait CallFuture: DurableFuture<Output = Result<Self::Response, TerminalError>> {
     type Response;
+
+    /// Returns a future that resolves with an [`InvocationHandle`] to this call's invocation,
+    /// without consuming or awaiting the response.
+    fn invocation_handle(
+        &self,
+    ) -> impl Future<Output = Result<InvocationHandle, TerminalError>> + Send;
+
+    /// Returns the invocation id of this call.
+    #[deprecated(
+        since = "0.11.0",
+        note = "use `invocation_handle().await?.invocation_id()` instead"
+    )]
+    fn invocation_id(&self) -> impl Future<Output = Result<String, TerminalError>> + Send;
 }

--- a/src/endpoint/context.rs
+++ b/src/endpoint/context.rs
@@ -1,6 +1,6 @@
 use crate::context::{
     CallFuture, DurableFuture, InvocationHandle, Request, RequestTarget, RunClosure, RunFuture,
-    RunRetryPolicy,
+    RunRetryPolicy, SendHandle,
 };
 use crate::endpoint::futures::async_result_poll::VmAsyncResultPollFuture;
 use crate::endpoint::futures::durable_future_impl::DurableFutureImpl;
@@ -15,9 +15,9 @@ use futures::future::{BoxFuture, Either, Shared};
 use futures::{FutureExt, TryFutureExt};
 use pin_project_lite::pin_project;
 use restate_sdk_shared_core::{
-    AwaitResponse, AwakeableHandle, CoreVM, Error as CoreError, Header, NonEmptyValue,
-    NotificationHandle, OnMaxAttempts, PayloadOptions, RetryPolicy, RunExitResult, RunHandle,
-    Target, TerminalFailure, UnresolvedFuture, VM, Value,
+    AttachInvocationTarget, AwaitResponse, AwakeableHandle, CoreVM, Error as CoreError, Header,
+    NonEmptyValue, NotificationHandle, OnMaxAttempts, PayloadOptions, RetryPolicy, RunExitResult,
+    RunHandle, Target, TerminalFailure, UnresolvedFuture, VM, Value,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -478,7 +478,7 @@ impl ContextInternal {
         headers: Vec<(String, String)>,
         req: Req,
         delay: Option<Duration>,
-    ) -> impl InvocationHandle {
+    ) -> SendHandle {
         let mut inner_lock = must_lock!(self.inner);
 
         let mut target: Target = request_target.into();
@@ -493,8 +493,8 @@ impl ContextInternal {
         let input = match Req::serialize(&req) {
             Ok(b) => b,
             Err(e) => {
-                inner_lock.fail(Error::serialization("call", e));
-                return Either::Right(TrapFuture::<()>::default());
+                inner_lock.fail(Error::serialization("send", e));
+                return SendHandle::new(self.clone(), TrapFuture::default().boxed());
             }
         };
 
@@ -513,7 +513,7 @@ impl ContextInternal {
             Ok(h) => h,
             Err(e) => {
                 inner_lock.fail(e.into());
-                return Either::Right(TrapFuture::<()>::default());
+                return SendHandle::new(self.clone(), TrapFuture::default().boxed());
             }
         };
         inner_lock.maybe_flip_span_replaying_field();
@@ -530,24 +530,115 @@ impl ContextInternal {
                 Ok(Value::InvocationId(s)) => Ok(Ok(s)),
                 Ok(v) => Err(ErrorInner::UnexpectedValueVariantForSyscall {
                     variant: <&'static str>::from(v),
-                    syscall: "call",
+                    syscall: "send",
                 }
                 .into()),
                 Err(e) => Err(e),
             }),
         );
 
-        Either::Left(SendRequestHandle {
-            invocation_id_future: invocation_id_fut.shared(),
-            ctx: self.clone(),
-        })
+        SendHandle::new(self.clone(), invocation_id_fut.boxed())
     }
 
-    pub fn invocation_handle(&self, invocation_id: String) -> impl InvocationHandle {
-        InvocationIdBackedInvocationHandle {
-            ctx: self.clone(),
-            invocation_id,
+    pub fn invocation_handle(&self, invocation_id: String) -> InvocationHandle {
+        InvocationHandle::new(self.clone(), invocation_id)
+    }
+
+    /// Cancel a target invocation (fire-and-forget).
+    pub fn cancel_invocation(&self, invocation_id: &str) {
+        let mut inner_lock = must_lock!(self.inner);
+        let _ = inner_lock
+            .vm
+            .sys_cancel_invocation(invocation_id.to_owned());
+        inner_lock.maybe_flip_span_replaying_field();
+    }
+
+    /// Attach to a target invocation, awaiting its output.
+    pub fn attach_invocation<T: Deserialize + 'static>(
+        &self,
+        invocation_id: String,
+    ) -> impl DurableFuture<Output = Result<T, TerminalError>> + Send + use<T> {
+        let mut inner_lock = must_lock!(self.inner);
+        let handle = unwrap_or_trap_durable_future!(
+            self,
+            inner_lock,
+            inner_lock
+                .vm
+                .sys_attach_invocation(AttachInvocationTarget::InvocationId(invocation_id))
+        );
+        inner_lock.maybe_flip_span_replaying_field();
+        drop(inner_lock);
+
+        let poll_future = get_async_result(Arc::clone(&self.inner), handle).map(|res| match res {
+            Ok(Value::Success(mut s)) => Ok(Ok(T::deserialize(&mut s)
+                .map_err(|e| Error::deserialization("attach_invocation", e))?)),
+            Ok(Value::Failure(f)) => Ok(Err(f.into())),
+            Ok(v) => Err(ErrorInner::UnexpectedValueVariantForSyscall {
+                variant: <&'static str>::from(v),
+                syscall: "attach_invocation",
+            }
+            .into()),
+            Err(e) => Err(e),
+        });
+
+        DurableFutureImpl::new(self.clone(), handle, Either::Left(poll_future))
+    }
+
+    /// Await a named signal on the current invocation.
+    pub fn signal<T: Deserialize + 'static>(
+        &self,
+        name: &str,
+    ) -> impl DurableFuture<Output = Result<T, TerminalError>> + Send + use<T> {
+        let mut inner_lock = must_lock!(self.inner);
+        let handle = unwrap_or_trap_durable_future!(
+            self,
+            inner_lock,
+            inner_lock.vm.create_signal_handle(name.to_owned())
+        );
+        inner_lock.maybe_flip_span_replaying_field();
+        drop(inner_lock);
+
+        let poll_future = get_async_result(Arc::clone(&self.inner), handle).map(|res| match res {
+            Ok(Value::Success(mut s)) => {
+                let t = T::deserialize(&mut s).map_err(|e| Error::deserialization("signal", e))?;
+                Ok(Ok(t))
+            }
+            Ok(Value::Failure(f)) => Ok(Err(f.into())),
+            Ok(v) => Err(ErrorInner::UnexpectedValueVariantForSyscall {
+                variant: <&'static str>::from(v),
+                syscall: "signal",
+            }
+            .into()),
+            Err(e) => Err(e),
+        });
+
+        DurableFutureImpl::new(self.clone(), handle, Either::Left(poll_future))
+    }
+
+    /// Resolve a named signal on a target invocation.
+    pub fn resolve_signal<T: Serialize>(&self, invocation_id: &str, name: &str, t: T) {
+        let mut inner_lock = must_lock!(self.inner);
+        match t.serialize() {
+            Ok(b) => {
+                let _ = inner_lock.vm.sys_complete_signal(
+                    invocation_id.to_owned(),
+                    name.to_owned(),
+                    NonEmptyValue::Success(b),
+                );
+            }
+            Err(e) => {
+                inner_lock.fail(Error::serialization("resolve_signal", e));
+            }
         }
+    }
+
+    /// Reject a named signal on a target invocation.
+    pub fn reject_signal(&self, invocation_id: &str, name: &str, failure: TerminalError) {
+        let _ = must_lock!(self.inner).vm.sys_complete_signal(
+            invocation_id.to_owned(),
+            name.to_owned(),
+            NonEmptyValue::Failure(failure.into()),
+        );
     }
 
     pub fn awakeable<T: Deserialize>(
@@ -1044,34 +1135,27 @@ where
     }
 }
 
-impl<InvIdFut, ResultFut> InvocationHandle for CallFutureImpl<InvIdFut, ResultFut>
-where
-    InvIdFut: Future<Output = Result<String, TerminalError>> + Send,
-{
-    fn invocation_id(&self) -> impl Future<Output = Result<String, TerminalError>> + Send {
-        Shared::clone(&self.invocation_id_future)
-    }
-
-    fn cancel(&self) -> impl Future<Output = Result<(), TerminalError>> + Send {
-        let cloned_invocation_id_fut = Shared::clone(&self.invocation_id_future);
-        let cloned_ctx = Arc::clone(&self.ctx.inner);
-        async move {
-            let inv_id = cloned_invocation_id_fut.await?;
-            let mut inner_lock = must_lock!(cloned_ctx);
-            let _ = inner_lock.vm.sys_cancel_invocation(inv_id);
-            inner_lock.maybe_flip_span_replaying_field();
-            drop(inner_lock);
-            Ok(())
-        }
-    }
-}
-
 impl<InvIdFut, ResultFut, Res> CallFuture for CallFutureImpl<InvIdFut, ResultFut>
 where
     InvIdFut: Future<Output = Result<String, TerminalError>> + Send,
     ResultFut: Future<Output = Result<Result<Res, TerminalError>, Error>> + Send,
 {
     type Response = Res;
+
+    fn invocation_handle(
+        &self,
+    ) -> impl Future<Output = Result<InvocationHandle, TerminalError>> + Send {
+        let invocation_id_fut = Shared::clone(&self.invocation_id_future);
+        let ctx = self.ctx.clone();
+        async move {
+            let invocation_id = invocation_id_fut.await?;
+            Ok(ctx.invocation_handle(invocation_id))
+        }
+    }
+
+    fn invocation_id(&self) -> impl Future<Output = Result<String, TerminalError>> + Send {
+        Shared::clone(&self.invocation_id_future)
+    }
 }
 
 impl<InvIdFut, ResultFut> crate::context::macro_support::SealedDurableFuture
@@ -1093,71 +1177,6 @@ where
     InvIdFut: Future<Output = Result<String, TerminalError>> + Send,
     ResultFut: Future<Output = Result<Result<Res, TerminalError>, Error>> + Send,
 {
-}
-
-struct SendRequestHandle<InvIdFut: Future> {
-    invocation_id_future: Shared<InvIdFut>,
-    ctx: ContextInternal,
-}
-
-impl<InvIdFut: Future<Output = Result<String, TerminalError>> + Send> InvocationHandle
-    for SendRequestHandle<InvIdFut>
-{
-    fn invocation_id(&self) -> impl Future<Output = Result<String, TerminalError>> + Send {
-        Shared::clone(&self.invocation_id_future)
-    }
-
-    fn cancel(&self) -> impl Future<Output = Result<(), TerminalError>> + Send {
-        let cloned_invocation_id_fut = Shared::clone(&self.invocation_id_future);
-        let cloned_ctx = Arc::clone(&self.ctx.inner);
-        async move {
-            let inv_id = cloned_invocation_id_fut.await?;
-            let mut inner_lock = must_lock!(cloned_ctx);
-            let _ = inner_lock.vm.sys_cancel_invocation(inv_id);
-            inner_lock.maybe_flip_span_replaying_field();
-            drop(inner_lock);
-            Ok(())
-        }
-    }
-}
-
-struct InvocationIdBackedInvocationHandle {
-    ctx: ContextInternal,
-    invocation_id: String,
-}
-
-impl InvocationHandle for InvocationIdBackedInvocationHandle {
-    fn invocation_id(&self) -> impl Future<Output = Result<String, TerminalError>> + Send {
-        ready(Ok(self.invocation_id.clone()))
-    }
-
-    fn cancel(&self) -> impl Future<Output = Result<(), TerminalError>> + Send {
-        let mut inner_lock = must_lock!(self.ctx.inner);
-        let _ = inner_lock
-            .vm
-            .sys_cancel_invocation(self.invocation_id.clone());
-        ready(Ok(()))
-    }
-}
-
-impl<A, B> InvocationHandle for Either<A, B>
-where
-    A: InvocationHandle,
-    B: InvocationHandle,
-{
-    fn invocation_id(&self) -> impl Future<Output = Result<String, TerminalError>> + Send {
-        match self {
-            Either::Left(l) => Either::Left(l.invocation_id()),
-            Either::Right(r) => Either::Right(r.invocation_id()),
-        }
-    }
-
-    fn cancel(&self) -> impl Future<Output = Result<(), TerminalError>> + Send {
-        match self {
-            Either::Left(l) => Either::Left(l.cancel()),
-            Either::Right(r) => Either::Right(r.cancel()),
-        }
-    }
 }
 
 impl Error {

--- a/src/endpoint/futures/intercept_error.rs
+++ b/src/endpoint/futures/intercept_error.rs
@@ -1,6 +1,5 @@
-use crate::context::{InvocationHandle, RunFuture, RunRetryPolicy};
+use crate::context::{RunFuture, RunRetryPolicy};
 use crate::endpoint::{ContextInternal, Error};
-use crate::errors::TerminalError;
 use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
@@ -57,15 +56,5 @@ where
     fn name(mut self, name: impl Into<String>) -> Self {
         self.fut = self.fut.name(name);
         self
-    }
-}
-
-impl<F: InvocationHandle> InvocationHandle for InterceptErrorFuture<F> {
-    fn invocation_id(&self) -> impl Future<Output = Result<String, TerminalError>> + Send {
-        self.fut.invocation_id()
-    }
-
-    fn cancel(&self) -> impl Future<Output = Result<(), TerminalError>> + Send {
-        self.fut.cancel()
     }
 }

--- a/src/endpoint/futures/trap.rs
+++ b/src/endpoint/futures/trap.rs
@@ -1,5 +1,3 @@
-use crate::context::InvocationHandle;
-use crate::errors::TerminalError;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -20,15 +18,5 @@ impl<T> Future for TrapFuture<T> {
     fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<T> {
         ctx.waker().wake_by_ref();
         Poll::Pending
-    }
-}
-
-impl<T> InvocationHandle for TrapFuture<T> {
-    fn invocation_id(&self) -> impl Future<Output = Result<String, TerminalError>> + Send {
-        TrapFuture::default()
-    }
-
-    fn cancel(&self) -> impl Future<Output = Result<(), TerminalError>> + Send {
-        TrapFuture::default()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 //! - State: [read][crate::context::ContextReadState] and [write](crate::context::ContextWriteState): Store and retrieve state in Restate's key-value store
 //! - [Scheduling & Timers][crate::context::ContextTimers]: Let a handler pause for a certain amount of time. Restate durably tracks the timer across failures.
 //! - [Awakeables][crate::context::ContextAwakeables]: Durable Futures to wait for events and the completion of external tasks.
+//! - [Signals][crate::context::ContextSignals]: Named durable promises scoped to an invocation, for communication between invocations.
 //! - [Error Handling][crate::errors]: Restate retries failures infinitely. Use `TerminalError` to stop retries.
 //! - [Serialization][crate::serde]: The SDK serializes results to send them to the Server. Includes [Schema Generation and payload metadata](crate::serde::PayloadMetadata) for documentation & discovery.
 //! - [Serving][crate::http_server]: Start an HTTP server to expose services.
@@ -511,9 +512,10 @@ pub mod prelude {
 
     pub use crate::context::{
         CallFuture, Context, ContextAwakeables, ContextClient, ContextPromises, ContextReadState,
-        ContextSideEffects, ContextTimers, ContextWriteState, DurableFuturesUnordered, HeaderMap,
-        InvocationHandle, ObjectContext, Request, RunFuture, RunRetryPolicy, SharedObjectContext,
-        SharedWorkflowContext, WorkflowContext,
+        ContextSideEffects, ContextSignals, ContextTimers, ContextWriteState,
+        DurableFuturesUnordered, HeaderMap, InvocationHandle, ObjectContext, Request, RunFuture,
+        RunRetryPolicy, SendHandle, SharedObjectContext, SharedWorkflowContext, SignalHandle,
+        WorkflowContext,
     };
     pub use crate::endpoint::{
         Endpoint, HandleOptions, HandlerOptions, ProtocolMode, ServiceOptions,

--- a/test-services/src/proxy.rs
+++ b/test-services/src/proxy.rs
@@ -75,10 +75,11 @@ impl Proxy {
         let invocation_id = if let Some(delay_millis) = req.delay_millis {
             request
                 .send_after(Duration::from_millis(delay_millis))
-                .invocation_id()
                 .await?
+                .invocation_id()
+                .to_owned()
         } else {
-            request.send().invocation_id().await?
+            request.send().await?.invocation_id().to_owned()
         };
 
         Ok(invocation_id)

--- a/test-services/src/test_utils_service.rs
+++ b/test-services/src/test_utils_service.rs
@@ -1,11 +1,29 @@
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use restate_sdk::prelude::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ResolveSignalRequest {
+    invocation_id: String,
+    signal_name: String,
+    value: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RejectSignalRequest {
+    invocation_id: String,
+    signal_name: String,
+    reason: String,
+}
 
 pub(crate) struct TestUtilsService;
 
@@ -88,7 +106,41 @@ impl TestUtilsService {
         ctx: Context<'_>,
         invocation_id: String,
     ) -> Result<(), TerminalError> {
-        ctx.invocation_handle(invocation_id).cancel().await?;
+        ctx.invocation_handle(invocation_id).cancel();
+        Ok(())
+    }
+
+    #[handler(name = "resolveSignal")]
+    async fn resolve_signal(
+        &self,
+        ctx: Context<'_>,
+        req: Json<ResolveSignalRequest>,
+    ) -> Result<(), HandlerError> {
+        let ResolveSignalRequest {
+            invocation_id,
+            signal_name,
+            value,
+        } = req.into_inner();
+        ctx.invocation_handle(invocation_id)
+            .signal(signal_name)
+            .resolve(value);
+        Ok(())
+    }
+
+    #[handler(name = "rejectSignal")]
+    async fn reject_signal(
+        &self,
+        ctx: Context<'_>,
+        req: Json<RejectSignalRequest>,
+    ) -> Result<(), HandlerError> {
+        let RejectSignalRequest {
+            invocation_id,
+            signal_name,
+            reason,
+        } = req.into_inner();
+        ctx.invocation_handle(invocation_id)
+            .signal(signal_name)
+            .reject(TerminalError::new(reason));
         Ok(())
     }
 }

--- a/test-services/src/virtual_object_command_interpreter.rs
+++ b/test-services/src/virtual_object_command_interpreter.rs
@@ -46,6 +46,8 @@ pub(crate) enum Command {
 pub(crate) enum AwaitableCommand {
     #[serde(rename = "createAwakeable")]
     CreateAwakeable { awakeable_key: String },
+    #[serde(rename = "createSignal")]
+    CreateSignal { signal_name: String },
     #[serde(rename = "sleep")]
     Sleep { timeout_millis: u64 },
     #[serde(rename = "runThrowTerminalException")]
@@ -109,6 +111,9 @@ impl VirtualObjectCommandInterpreter {
                             let (awakeable_id, fut) = context.awakeable::<String>();
                             context.set::<String>(&format!("awk-{awakeable_key}"), awakeable_id);
                             fut.await?
+                        }
+                        AwaitableCommand::CreateSignal { signal_name } => {
+                            context.signal::<String>(&signal_name).await?
                         }
                         AwaitableCommand::Sleep { timeout_millis } => {
                             context


### PR DESCRIPTION
## Summary

Adds **signals** to the Rust SDK — named, one-shot durable promises scoped to an invocation, matching the feature already shipped in the TypeScript, Python, and Go SDKs. Built on the `create_signal_handle` / `sys_complete_signal` / `sys_attach_invocation` syscalls that were already present (unused) in `restate-sdk-shared-core 0.10.0`, so **no dependency bump**.

A handler awaits a signal by name; any other handler completes it by targeting the awaiter's **invocation id + signal name** — i.e. "awakeables addressed by `(invocation_id, name)`", with no opaque token to exfiltrate.

```rust
// await side (any context; a DurableFuture, so it works in select!)
let approved: bool = ctx.signal::<bool>("approved").await?;

// send side (fluent, sync fire-and-forget)
ctx.invocation_handle(id).signal("approved").resolve(true);
ctx.invocation_handle(id).signal("approved").reject(TerminalError::new("nope"));
```

## `InvocationHandle` redesign (breaking)

To make the signal send-side ergonomic (and generally cleaner), `InvocationHandle` becomes an **id-backed struct** with synchronous accessors:

- `invocation_id() -> &str` (was `async -> Result<String, _>`)
- `cancel()` — sync fire-and-forget (was async)
- `attach::<T>()` — **new**, awaits the invocation's output (`sys_attach_invocation`)
- `signal(name)` — **new**, returns a `SignalHandle` with `resolve`/`reject`

Consequently:

- `send()` / `send_after()` now return an awaitable **`SendHandle`** (`impl IntoFuture` → `InvocationHandle`). The send is issued eagerly, so bare `client.foo().send();` still fire-and-forgets. `IntoFuture` (rather than a bare `impl Future`) keeps fire-and-forget free of the must-use lint and keeps the eager send/lazy-id split clean.
- `call()` still awaits to the response and gains **`invocation_handle(&self)`** (takes `&self`, does not consume the future); it retains a `#[deprecated]` `invocation_id()` to soften the break. `CallFuture` drops its `InvocationHandle` supertrait.

## Test-services / e2e

- `createSignal` command added to `VirtualObjectCommandInterpreter`.
- `resolveSignal` / `rejectSignal` handlers added to `TestUtilsService`.

Matches the contract implemented in the other SDKs so the shared e2e suite exercises the flows.

## Example

New `examples/signals.rs` (await / resolve / reject).

## Verification

- `cargo build --workspace --all-features --all-targets` ✅
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` ✅
- unit + integration + doc tests ✅ (the new `# Signals` doc examples compile)
- Docker-based e2e (testcontainers) not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)