### PR TITLE
feat: support scope and limit key

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -26,6 +26,9 @@ pub struct Context<'ctx> {
     #[cfg(feature = "rand")]
     std_rng: rand::prelude::StdRng,
     headers: HeaderMap,
+    scope: Option<String>,
+    limit_key: Option<String>,
+    idempotency_key: Option<String>,
     inner: &'ctx ContextInternal,
 }
 
@@ -44,6 +47,21 @@ impl Context<'_> {
     pub fn headers_mut(&mut self) -> &HeaderMap {
         &mut self.headers
     }
+
+    /// Scope this invocation was submitted with, if any.
+    pub fn scope(&self) -> Option<&str> {
+        self.scope.as_deref()
+    }
+
+    /// Limit key this invocation was submitted with, if any.
+    pub fn limit_key(&self) -> Option<&str> {
+        self.limit_key.as_deref()
+    }
+
+    /// Idempotency key this invocation was submitted with, if any.
+    pub fn idempotency_key(&self) -> Option<&str> {
+        self.idempotency_key.as_deref()
+    }
 }
 
 impl<'ctx> From<(&'ctx ContextInternal, InputMetadata)> for Context<'ctx> {
@@ -54,6 +72,9 @@ impl<'ctx> From<(&'ctx ContextInternal, InputMetadata)> for Context<'ctx> {
             #[cfg(feature = "rand")]
             std_rng: rand::prelude::SeedableRng::seed_from_u64(value.1.random_seed),
             headers: value.1.headers,
+            scope: value.1.scope,
+            limit_key: value.1.limit_key,
+            idempotency_key: value.1.idempotency_key,
             inner: value.0,
         }
     }
@@ -67,6 +88,9 @@ pub struct SharedObjectContext<'ctx> {
     #[cfg(feature = "rand")]
     std_rng: rand::prelude::StdRng,
     headers: HeaderMap,
+    scope: Option<String>,
+    limit_key: Option<String>,
+    idempotency_key: Option<String>,
     pub(crate) inner: &'ctx ContextInternal,
 }
 
@@ -90,6 +114,21 @@ impl SharedObjectContext<'_> {
     pub fn headers_mut(&mut self) -> &HeaderMap {
         &mut self.headers
     }
+
+    /// Scope this invocation was submitted with, if any.
+    pub fn scope(&self) -> Option<&str> {
+        self.scope.as_deref()
+    }
+
+    /// Limit key this invocation was submitted with, if any.
+    pub fn limit_key(&self) -> Option<&str> {
+        self.limit_key.as_deref()
+    }
+
+    /// Idempotency key this invocation was submitted with, if any.
+    pub fn idempotency_key(&self) -> Option<&str> {
+        self.idempotency_key.as_deref()
+    }
 }
 
 impl<'ctx> From<(&'ctx ContextInternal, InputMetadata)> for SharedObjectContext<'ctx> {
@@ -101,6 +140,9 @@ impl<'ctx> From<(&'ctx ContextInternal, InputMetadata)> for SharedObjectContext<
             #[cfg(feature = "rand")]
             std_rng: rand::prelude::SeedableRng::seed_from_u64(value.1.random_seed),
             headers: value.1.headers,
+            scope: value.1.scope,
+            limit_key: value.1.limit_key,
+            idempotency_key: value.1.idempotency_key,
             inner: value.0,
         }
     }
@@ -114,6 +156,9 @@ pub struct ObjectContext<'ctx> {
     #[cfg(feature = "rand")]
     std_rng: rand::prelude::StdRng,
     headers: HeaderMap,
+    scope: Option<String>,
+    limit_key: Option<String>,
+    idempotency_key: Option<String>,
     pub(crate) inner: &'ctx ContextInternal,
 }
 
@@ -137,6 +182,21 @@ impl ObjectContext<'_> {
     pub fn headers_mut(&mut self) -> &HeaderMap {
         &mut self.headers
     }
+
+    /// Scope this invocation was submitted with, if any.
+    pub fn scope(&self) -> Option<&str> {
+        self.scope.as_deref()
+    }
+
+    /// Limit key this invocation was submitted with, if any.
+    pub fn limit_key(&self) -> Option<&str> {
+        self.limit_key.as_deref()
+    }
+
+    /// Idempotency key this invocation was submitted with, if any.
+    pub fn idempotency_key(&self) -> Option<&str> {
+        self.idempotency_key.as_deref()
+    }
 }
 
 impl<'ctx> From<(&'ctx ContextInternal, InputMetadata)> for ObjectContext<'ctx> {
@@ -148,6 +208,9 @@ impl<'ctx> From<(&'ctx ContextInternal, InputMetadata)> for ObjectContext<'ctx> 
             #[cfg(feature = "rand")]
             std_rng: rand::prelude::SeedableRng::seed_from_u64(value.1.random_seed),
             headers: value.1.headers,
+            scope: value.1.scope,
+            limit_key: value.1.limit_key,
+            idempotency_key: value.1.idempotency_key,
             inner: value.0,
         }
     }
@@ -161,6 +224,9 @@ pub struct SharedWorkflowContext<'ctx> {
     #[cfg(feature = "rand")]
     std_rng: rand::prelude::StdRng,
     headers: HeaderMap,
+    scope: Option<String>,
+    limit_key: Option<String>,
+    idempotency_key: Option<String>,
     pub(crate) inner: &'ctx ContextInternal,
 }
 
@@ -173,6 +239,9 @@ impl<'ctx> From<(&'ctx ContextInternal, InputMetadata)> for SharedWorkflowContex
             #[cfg(feature = "rand")]
             std_rng: rand::prelude::SeedableRng::seed_from_u64(value.1.random_seed),
             headers: value.1.headers,
+            scope: value.1.scope,
+            limit_key: value.1.limit_key,
+            idempotency_key: value.1.idempotency_key,
             inner: value.0,
         }
     }
@@ -198,6 +267,21 @@ impl SharedWorkflowContext<'_> {
     pub fn headers_mut(&mut self) -> &HeaderMap {
         &mut self.headers
     }
+
+    /// Scope this invocation was submitted with, if any.
+    pub fn scope(&self) -> Option<&str> {
+        self.scope.as_deref()
+    }
+
+    /// Limit key this invocation was submitted with, if any.
+    pub fn limit_key(&self) -> Option<&str> {
+        self.limit_key.as_deref()
+    }
+
+    /// Idempotency key this invocation was submitted with, if any.
+    pub fn idempotency_key(&self) -> Option<&str> {
+        self.idempotency_key.as_deref()
+    }
 }
 
 /// Workflow handler context.
@@ -208,6 +292,9 @@ pub struct WorkflowContext<'ctx> {
     #[cfg(feature = "rand")]
     std_rng: rand::prelude::StdRng,
     headers: HeaderMap,
+    scope: Option<String>,
+    limit_key: Option<String>,
+    idempotency_key: Option<String>,
     pub(crate) inner: &'ctx ContextInternal,
 }
 
@@ -220,6 +307,9 @@ impl<'ctx> From<(&'ctx ContextInternal, InputMetadata)> for WorkflowContext<'ctx
             #[cfg(feature = "rand")]
             std_rng: rand::prelude::SeedableRng::seed_from_u64(value.1.random_seed),
             headers: value.1.headers,
+            scope: value.1.scope,
+            limit_key: value.1.limit_key,
+            idempotency_key: value.1.idempotency_key,
             inner: value.0,
         }
     }
@@ -244,6 +334,21 @@ impl WorkflowContext<'_> {
     /// Get request headers.
     pub fn headers_mut(&mut self) -> &HeaderMap {
         &mut self.headers
+    }
+
+    /// Scope this invocation was submitted with, if any.
+    pub fn scope(&self) -> Option<&str> {
+        self.scope.as_deref()
+    }
+
+    /// Limit key this invocation was submitted with, if any.
+    pub fn limit_key(&self) -> Option<&str> {
+        self.limit_key.as_deref()
+    }
+
+    /// Idempotency key this invocation was submitted with, if any.
+    pub fn idempotency_key(&self) -> Option<&str> {
+        self.idempotency_key.as_deref()
     }
 }
 
@@ -355,6 +460,31 @@ impl<'ctx, CTX: private::SealedContext<'ctx>> ContextTimers<'ctx> for CTX {}
 /// **No need for manual retry logic**:
 /// Restate proxies all the calls and logs them in the journal.
 /// In case of failures, Restate takes care of retries, so you don't need to implement this yourself here.
+///
+/// ## Idempotency key, scope and concurrency limit key
+///
+/// Calls and sends can carry an idempotency key, a scope, and a concurrency limit key.
+/// A *scope* is a sub-grouping of resources that gets co-located by the restate-server (idempotency
+/// keys are scoped). A *limit key* enforces hierarchical concurrency limits within the scope, and can
+/// only be used together with a scope.
+///
+/// ```rust,no_run
+/// # #[path = "../../examples/services/mod.rs"]
+/// # mod services;
+/// # use services::my_service::MyServiceClient;
+/// # use restate_sdk::prelude::*;
+/// #
+/// # async fn greet(ctx: Context<'_>, greeting: String) -> Result<(), HandlerError> {
+///     ctx.service_client::<MyServiceClient>()
+///         .my_handler(String::from("Hi!"))
+///         .idempotency_key("req-1")
+///         .scope("tenant-123")
+///         .limit_key("api-key/user42")
+///         .call()
+///         .await?;
+/// #    Ok(())
+/// # }
+/// ```
 ///
 /// ## Sending messages
 ///

--- a/src/context/request.rs
+++ b/src/context/request.rs
@@ -77,6 +77,8 @@ pub struct Request<'a, Req, Res = ()> {
     ctx: &'a ContextInternal,
     request_target: RequestTarget,
     idempotency_key: Option<String>,
+    scope: Option<String>,
+    limit_key: Option<String>,
     headers: Vec<(String, String)>,
     req: Req,
     res: PhantomData<Res>,
@@ -88,6 +90,8 @@ impl<'a, Req, Res> Request<'a, Req, Res> {
             ctx,
             request_target,
             idempotency_key: None,
+            scope: None,
+            limit_key: None,
             headers: vec![],
             req,
             res: PhantomData,
@@ -105,6 +109,26 @@ impl<'a, Req, Res> Request<'a, Req, Res> {
         self
     }
 
+    /// Route this request within the given scope.
+    ///
+    /// A scope is a sub-grouping of resources (invocations, virtual object instances, workflow
+    /// executions). Under the hood the scope contributes to the partition key, so all resources
+    /// in a scope get co-located by the restate-server. Idempotency keys are scoped, so the same
+    /// idempotency key in two different scopes refers to two distinct requests.
+    pub fn scope(mut self, scope: impl Into<String>) -> Self {
+        self.scope = Some(scope.into());
+        self
+    }
+
+    /// Add a concurrency limit key to the request.
+    ///
+    /// The limit key enforces hierarchical concurrency limits on invocations sharing the same
+    /// scope. It can only be used in conjunction with a scope (see [`Request::scope`]).
+    pub fn limit_key(mut self, limit_key: impl Into<String>) -> Self {
+        self.limit_key = Some(limit_key.into());
+        self
+    }
+
     /// Call a service. This returns a future encapsulating the response.
     pub fn call(self) -> impl CallFuture<Response = Res> + Send
     where
@@ -114,6 +138,8 @@ impl<'a, Req, Res> Request<'a, Req, Res> {
         self.ctx.call(
             self.request_target,
             self.idempotency_key,
+            self.scope,
+            self.limit_key,
             self.headers,
             self.req,
         )
@@ -130,6 +156,8 @@ impl<'a, Req, Res> Request<'a, Req, Res> {
         self.ctx.send(
             self.request_target,
             self.idempotency_key,
+            self.scope,
+            self.limit_key,
             self.headers,
             self.req,
             None,
@@ -146,6 +174,8 @@ impl<'a, Req, Res> Request<'a, Req, Res> {
         self.ctx.send(
             self.request_target,
             self.idempotency_key,
+            self.scope,
+            self.limit_key,
             self.headers,
             self.req,
             Some(delay),

--- a/src/endpoint/context.rs
+++ b/src/endpoint/context.rs
@@ -121,6 +121,9 @@ pub struct InputMetadata {
     pub random_seed: u64,
     pub key: String,
     pub headers: http::HeaderMap<String>,
+    pub scope: Option<String>,
+    pub limit_key: Option<String>,
+    pub idempotency_key: Option<String>,
 }
 
 impl From<RequestTarget> for Target {
@@ -227,6 +230,9 @@ impl ContextInternal {
                             random_seed: raw_input.random_seed,
                             key: raw_input.key,
                             headers,
+                            scope: raw_input.scope,
+                            limit_key: raw_input.limit_key,
+                            idempotency_key: raw_input.idempotency_key,
                         },
                     ))
                 });
@@ -390,6 +396,8 @@ impl ContextInternal {
         &self,
         request_target: RequestTarget,
         idempotency_key: Option<String>,
+        scope: Option<String>,
+        limit_key: Option<String>,
         headers: Vec<(String, String)>,
         req: Req,
     ) -> impl CallFuture<Response = Res> + Send {
@@ -397,6 +405,8 @@ impl ContextInternal {
 
         let mut target: Target = request_target.into();
         target.idempotency_key = idempotency_key;
+        target.scope = scope;
+        target.limit_key = limit_key;
         target.headers = headers
             .into_iter()
             .map(|(k, v)| Header {
@@ -471,10 +481,13 @@ impl ContextInternal {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn send<Req: Serialize>(
         &self,
         request_target: RequestTarget,
         idempotency_key: Option<String>,
+        scope: Option<String>,
+        limit_key: Option<String>,
         headers: Vec<(String, String)>,
         req: Req,
         delay: Option<Duration>,
@@ -483,6 +496,8 @@ impl ContextInternal {
 
         let mut target: Target = request_target.into();
         target.idempotency_key = idempotency_key;
+        target.scope = scope;
+        target.limit_key = limit_key;
         target.headers = headers
             .into_iter()
             .map(|(k, v)| Header {

--- a/test-services/src/proxy.rs
+++ b/test-services/src/proxy.rs
@@ -13,6 +13,8 @@ pub(crate) struct ProxyRequest {
     virtual_object_key: Option<String>,
     handler_name: String,
     idempotency_key: Option<String>,
+    scope: Option<String>,
+    limit_key: Option<String>,
     message: Vec<u8>,
     delay_millis: Option<u64>,
 }
@@ -57,6 +59,12 @@ impl Proxy {
         if let Some(idempotency_key) = req.idempotency_key {
             request = request.idempotency_key(idempotency_key);
         }
+        if let Some(scope) = req.scope {
+            request = request.scope(scope);
+        }
+        if let Some(limit_key) = req.limit_key {
+            request = request.limit_key(limit_key);
+        }
         Ok(request.call().await?.into())
     }
 
@@ -70,6 +78,12 @@ impl Proxy {
         let mut request = ctx.request::<_, ()>(req.to_target(), req.message);
         if let Some(idempotency_key) = req.idempotency_key {
             request = request.idempotency_key(idempotency_key);
+        }
+        if let Some(scope) = req.scope {
+            request = request.scope(scope);
+        }
+        if let Some(limit_key) = req.limit_key {
+            request = request.limit_key(limit_key);
         }
 
         let invocation_id = if let Some(delay_millis) = req.delay_millis {
@@ -99,6 +113,12 @@ impl Proxy {
                 ctx.request::<_, Vec<u8>>(req.proxy_request.to_target(), req.proxy_request.message);
             if let Some(idempotency_key) = req.proxy_request.idempotency_key {
                 restate_req = restate_req.idempotency_key(idempotency_key);
+            }
+            if let Some(scope) = req.proxy_request.scope {
+                restate_req = restate_req.scope(scope);
+            }
+            if let Some(limit_key) = req.proxy_request.limit_key {
+                restate_req = restate_req.limit_key(limit_key);
             }
             if req.one_way_call {
                 if let Some(delay_millis) = req.proxy_request.delay_millis {


### PR DESCRIPTION
## What

Wires the service-protocol **v7** `scope` and `limit_key` routing options through the SDK, matching the [TypeScript SDK](https://github.com/restatedev/sdk-typescript) (PR #767). The shared-core `Target`/`Input` structs already carried these fields — this PR actually plumbs them.

### Outgoing calls — `Request` builder
Adds `.scope(..)` and `.limit_key(..)` alongside the existing `.idempotency_key(..)`, propagated onto the shared-core `Target`:

```rust
ctx.service_client::<MyServiceClient>()
    .my_handler(input)
    .idempotency_key("req-1")
    .scope("tenant-123")
    .limit_key("api-key/user42")
    .call()
    .await?;
```

- **scope** — a sub-grouping of resources co-located by the restate-server (idempotency keys are scoped).
- **limit key** — hierarchical concurrency limit within a scope; only valid together with a scope.

### Incoming (callee request) — metadata exposure
`InputMetadata` now carries the `scope`/`limit_key`/`idempotency_key` the current invocation was submitted with, exposed on all context types:

```rust
ctx.scope()            // Option<&str>
ctx.limit_key()        // Option<&str>
ctx.idempotency_key()  // Option<&str>
```

### e2e
Wires `scope`/`limit_key` through the `Proxy` test service, mirroring the TS `proxy.ts` so the cross-SDK e2e suite exercises propagation.

## Notes
- Followed the existing per-call builder idiom rather than adding the TS `ctx.scope("x")` scoped-context sugar (codegen-heavy, deliberate non-goal for now).
- No dedicated unit test for message-level propagation; that's covered when we move to the new integration tests.

## Verification
`cargo build --all-features`, full `cargo test`, doctests (incl. the new builder example), and `cargo clippy --all-targets --workspace --all-features -- -D warnings` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)