### PR TITLE
Fix wasm32 failures and panics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,33 @@ jobs:
 
       - name: Run verify
         run: just verify
+
+  wasm32:
+    name: wasm32 checks
+    runs-on: warp-ubuntu-latest-x64-4x
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+          target: wasm32-unknown-unknown
+          rustflags: ""
+          cache: false
+
+      - name: Setup Rust Caching
+        uses: WarpBuilds/rust-cache@v2
+        with:
+          cache-on-failure: "true"
+
+      - name: Setup just
+        uses: extractions/setup-just@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run wasm32 checks
+        run: just check-wasm32

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,17 @@ http-serde = { version = "2.1.1", optional = true }
 aws_lambda_events = { version = "1.0", optional = true }
 lambda_runtime = { version = "1.0", optional = true }
 
+# wasm32-unknown-unknown (browsers, Cloudflare Workers, ...) has no std clock and no OS
+# entropy source: `std::time::{Instant, SystemTime}::now()` abort at runtime and
+# `getrandom` needs a backend selected. `web-time` provides std-compatible clocks backed
+# by `performance.now()` / `Date.now()`. The getrandom backends cover jsonwebtoken via
+# shared-core (0.2) and rand 0.10 (0.4); consumers can still override the latter with
+# `--cfg getrandom_backend="..."`. Guarded by `just check-wasm32`.
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+web-time = "1.1"
+getrandom02 = { package = "getrandom", version = "0.2", features = ["js"] }
+getrandom04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+
 [dev-dependencies]
 base64 = "0.22"
 bs58 = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,4 +168,4 @@ syn = "2.0"
 typify = { version = "0.6" }
 
 [workspace]
-members = ["macros", "test-services", "testcontainers"]
+members = ["macros", "test-services", "testcontainers", "wasm-check"]

--- a/justfile
+++ b/justfile
@@ -57,6 +57,27 @@ clippy: (_target-installed target)
 # Runs all lints (fmt, clippy, deny)
 lint: check-fmt clippy
 
+# wasm32-unknown-unknown has no std clock and no Tokio runtime: `std::time::{Instant,
+# SystemTime}::now()` and `tokio::time::*` compile but abort at runtime. Two guards:
+# the `disallowed-methods` lint in wasm-check/clippy.toml over the SDK's own source
+# (selected via CLIPPY_CONF_DIR so native clippy is unaffected), and a release build
+# of `wasm-check` — which reaches every SDK path — searched for the panic strings
+# those calls compile to, catching them inside dependencies too.
+# Run by its own CI job, not by `verify`.
+check-wasm32: (_target-installed "wasm32-unknown-unknown")
+    #!/usr/bin/env bash
+    set -euo pipefail
+    CLIPPY_CONF_DIR="$PWD/wasm-check" cargo clippy --target wasm32-unknown-unknown -p restate-sdk -p restate-sdk-wasm-check \
+        --no-default-features --features restate-sdk/rand,restate-sdk/uuid,restate-sdk/rust_crypto -- -D warnings
+    cargo build --release --target wasm32-unknown-unknown -p restate-sdk-wasm-check
+    wasm=target/wasm32-unknown-unknown/release/restate_sdk_wasm_check.wasm
+    for needle in 'time not implemented on this platform' 'there is no reactor running'; do
+        if grep -a -q "$needle" "$wasm"; then
+            echo "error: '$needle' reachable in $wasm — a std::time / tokio::time clock is on a wasm32 path" >&2
+            exit 1
+        fi
+    done
+
 # Checks the SDK's minimal build and both tunnel crypto-provider configurations.
 check-sdk-features: (_target-installed target)
     cargo check {{ _target-option }} -p restate-sdk --no-default-features

--- a/src/endpoint/context.rs
+++ b/src/endpoint/context.rs
@@ -27,7 +27,14 @@ use std::mem;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, ready};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::Duration;
+// wasm32-unknown-unknown has no std clock: `std::time::{Instant, SystemTime}::now()`
+// abort with "time not implemented on this platform". `web_time` exposes the same API
+// backed by `performance.now()` / `Date.now()`. Guarded by `just check-wasm32`.
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+use std::time::{Instant, SystemTime};
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use web_time::{Instant, SystemTime};
 
 pub struct ContextInternalInner {
     pub(crate) vm: CoreVM,
@@ -879,7 +886,7 @@ impl ContextInternal {
     /// This ensures we don't close the HTTP/2 response stream before the request
     /// stream is done, which causes connection errors on proxies like Google Cloud Run.
     pub(crate) async fn drain_input(&self) -> Result<(), ErrorInner> {
-        tokio::time::timeout(Duration::from_secs(60), async {
+        let drain = async {
             loop {
                 let result = poll_fn(|cx| {
                     let mut inner = must_lock!(self.inner);
@@ -892,13 +899,22 @@ impl ContextInternal {
                     Some(Err(e)) => return Err(ErrorInner::InputDrain(e)),
                 }
             }
-        })
-        .await
-        .unwrap_or_else(|_| {
-            Err(ErrorInner::InputDrain(
-                "Timed out draining input stream after 60s".into(),
-            ))
-        })
+        };
+
+        // wasm32-unknown-unknown has no Tokio runtime to drive the timer, so the drain
+        // is bounded by the host's request lifetime there instead.
+        #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+        let drain = async {
+            tokio::time::timeout(Duration::from_secs(60), drain)
+                .await
+                .unwrap_or_else(|_| {
+                    Err(ErrorInner::InputDrain(
+                        "Timed out draining input stream after 60s".into(),
+                    ))
+                })
+        };
+
+        drain.await
     }
 
     pub(super) fn fail(&self, e: Error) {

--- a/wasm-check/Cargo.toml
+++ b/wasm-check/Cargo.toml
@@ -3,7 +3,7 @@ name = "restate-sdk-wasm-check"
 version = "0.0.0"
 edition = "2024"
 publish = false
-description = "CI-only: wasm32-unknown-unknown lint + no-std-clock binary check for restate-sdk. See src/lib.rs."
+description = "CI-only: wasm32-unknown-unknown no-std-clock binary check for restate-sdk. See src/lib.rs."
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -13,7 +13,3 @@ restate-sdk = { path = "..", default-features = false, features = ["rand", "uuid
 bytes = "1"
 http = "1"
 http-body-util = "0.1"
-
-[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-getrandom02 = { package = "getrandom", version = "0.2", features = ["js"] }   # jsonwebtoken (request identity)
-getrandom04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] } # rand 0.10

--- a/wasm-check/Cargo.toml
+++ b/wasm-check/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "restate-sdk-wasm-check"
+version = "0.0.0"
+edition = "2024"
+publish = false
+description = "CI-only: wasm32-unknown-unknown lint + no-std-clock binary check for restate-sdk. See src/lib.rs."
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+restate-sdk = { path = "..", default-features = false, features = ["rand", "uuid", "rust_crypto"] }
+bytes = "1"
+http = "1"
+http-body-util = "0.1"
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+getrandom02 = { package = "getrandom", version = "0.2", features = ["js"] }   # jsonwebtoken (request identity)
+getrandom04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] } # rand 0.10

--- a/wasm-check/clippy.toml
+++ b/wasm-check/clippy.toml
@@ -1,0 +1,13 @@
+# Clocks that panic on wasm32-unknown-unknown ("time not implemented on this
+# platform") or need a Tokio runtime. Deliberately NOT at the repo root: clippy
+# config applies to every crate beneath it, and the SDK's native tests use these
+# clocks legitimately. `just check-wasm32` selects this file via CLIPPY_CONF_DIR,
+# so the ban is active only when linting for that target.
+disallowed-methods = [
+  { path = "std::time::Instant::now",      reason = "panics on wasm32-unknown-unknown; use web_time::Instant" },
+  { path = "std::time::SystemTime::now",   reason = "panics on wasm32-unknown-unknown; use web_time::SystemTime" },
+  { path = "tokio::time::timeout",         reason = "needs a Tokio runtime; cfg it off or use a JS timer on wasm32-unknown-unknown" },
+  { path = "tokio::time::sleep",           reason = "needs a Tokio runtime; cfg it off or use a JS timer on wasm32-unknown-unknown" },
+  { path = "tokio::time::interval",        reason = "needs a Tokio runtime" },
+  { path = "tokio::time::Instant::now",    reason = "panics on wasm32-unknown-unknown" },
+]

--- a/wasm-check/src/lib.rs
+++ b/wasm-check/src/lib.rs
@@ -1,0 +1,57 @@
+//! CI-only crate; see Cargo.toml.
+//!
+//! Two jobs:
+//!
+//! 1. Supply the `getrandom` backends so `cargo clippy -p restate-sdk -p
+//!    restate-sdk-wasm-check --target wasm32-unknown-unknown` resolves, which
+//!    lets the `disallowed-methods` lint in `wasm-check/clippy.toml` (selected
+//!    via `CLIPPY_CONF_DIR` in `just check-wasm32`) run against the SDK.
+//! 2. Export one function that reaches every clock-touching SDK path (`ctx.run`,
+//!    `sleep`, `send_after`, `drain_input`), so a release build of this crate for
+//!    wasm32 retains them and the binary can be searched for the
+//!    "time not implemented on this platform" panic that `std::time` compiles to
+//!    on that target. Unlike the lint, this sees through dependencies.
+
+use std::time::Duration;
+
+use restate_sdk::prelude::*;
+
+struct Probe;
+
+#[restate_sdk::object]
+impl Probe {
+    #[handler]
+    async fn run(&self, ctx: ObjectContext<'_>) -> Result<u32, HandlerError> {
+        let n: u32 = ctx.run(|| async { Ok(42) }).await?;
+        ctx.sleep(Duration::from_millis(1)).await?;
+        ctx.object_client::<ProbeClient>("other")
+            .ping()
+            .send_after(Duration::from_secs(1));
+        Ok(n)
+    }
+
+    #[handler]
+    async fn ping(&self, _ctx: ObjectContext<'_>) -> Result<(), HandlerError> {
+        Ok(())
+    }
+}
+
+/// Reachable from the wasm export table so the linker keeps the whole
+/// invocation path. Never meant to be called.
+#[unsafe(no_mangle)]
+pub extern "C" fn restate_sdk_wasm_check_probe() -> u16 {
+    let endpoint = Endpoint::builder().bind(Probe).build();
+    let req = http::Request::builder()
+        .uri("/invoke/Probe/run")
+        .body(http_body_util::Full::new(bytes::Bytes::new()))
+        .unwrap();
+    endpoint
+        .handle_with_options(
+            req,
+            HandleOptions {
+                protocol_mode: ProtocolMode::RequestResponse,
+            },
+        )
+        .status()
+        .as_u16()
+}

--- a/wasm-check/src/lib.rs
+++ b/wasm-check/src/lib.rs
@@ -1,16 +1,12 @@
 //! CI-only crate; see Cargo.toml.
 //!
-//! Two jobs:
-//!
-//! 1. Supply the `getrandom` backends so `cargo clippy -p restate-sdk -p
-//!    restate-sdk-wasm-check --target wasm32-unknown-unknown` resolves, which
-//!    lets the `disallowed-methods` lint in `wasm-check/clippy.toml` (selected
-//!    via `CLIPPY_CONF_DIR` in `just check-wasm32`) run against the SDK.
-//! 2. Export one function that reaches every clock-touching SDK path (`ctx.run`,
-//!    `sleep`, `send_after`, `drain_input`), so a release build of this crate for
-//!    wasm32 retains them and the binary can be searched for the
-//!    "time not implemented on this platform" panic that `std::time` compiles to
-//!    on that target. Unlike the lint, this sees through dependencies.
+//! Exports one function that reaches every clock-touching SDK path (`ctx.run`,
+//! `sleep`, `send_after`, `drain_input`), so a release build of this crate for
+//! wasm32-unknown-unknown retains them and the binary can be searched for the
+//! "time not implemented on this platform" / "there is no reactor running" panics
+//! that `std::time` / `tokio::time` compile to on that target. Unlike the
+//! `disallowed-methods` lint (`wasm-check/clippy.toml`, selected via
+//! `CLIPPY_CONF_DIR` in `just check-wasm32`), this sees through dependencies.
 
 use std::time::Duration;
 


### PR DESCRIPTION
This PR adds a CI job for checking the SDK on wasm32.

It also fixes a couple issues that otherwise result in panic in wasm32 environments.